### PR TITLE
Core judge/async problem creation

### DIFF
--- a/src/Services/CoreJudge/CoreJudge.API/Controllers/TestcasesController.cs
+++ b/src/Services/CoreJudge/CoreJudge.API/Controllers/TestcasesController.cs
@@ -1,8 +1,9 @@
-﻿using BuildingBlocks.Identity;
+using BuildingBlocks.Identity;
 using CoreJudge.Application.Features.Testcases.Commands.Delete;
 using CoreJudge.Application.Features.Testcases.Commands.Update;
 using CoreJudge.Application.Features.Testcases.Queries.GetTestCasesByProblemId;
 using CoreJudge.Application.Features.TestCases.Commands.Create;
+using CoreJudge.Application.Features.TestCases.Commands.BulkCreate;
 using CoreJudge.Domain.Premitives;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,8 +15,14 @@ namespace CoreJudge.API.Controllers
 
     public class TestcasesController : BaseController
     {
+        // POST /api/testcases
         [HttpPost]
         public async Task<ActionResult<Response>> CreateTestcaseAsync(CreateTestcaseCommand command)
+         => ResponseResult(await mediator.Send(command));
+
+        // POST /api/testcases/bulk
+        [HttpPost("bulk")]
+        public async Task<ActionResult<Response>> BulkCreateTestcasesAsync(BulkCreateTestcasesCommand command)
          => ResponseResult(await mediator.Send(command));
 
         [HttpGet("{problemId}")]

--- a/src/Services/CoreJudge/CoreJudge.API/Extentions/DataSeeding.cs
+++ b/src/Services/CoreJudge/CoreJudge.API/Extentions/DataSeeding.cs
@@ -1,0 +1,411 @@
+﻿using CoreJudge.Domain.Models;
+using CoreJudge.Domain.Models.Entities;
+using CoreJudge.Infrastructure.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace CoreJudge.API.Extentions;
+
+public static class DataSeeding
+{
+    public static async Task SeedDataAsync(this IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var bus = scope.ServiceProvider.GetRequiredService<MassTransit.IPublishEndpoint>();
+        var guid = Guid.NewGuid();
+
+
+        var Contests = await db.Contests.ToListAsync();
+
+        //if (Contests.Any())
+        //    return;
+        var problems = ConstructProblems(guid);
+        var contest = new Contest
+        {
+            ContestSetterId = guid,
+            Name = "Sample Contest",
+            StartDate = DateTime.UtcNow.AddHours(-10),
+            EndDate = DateTime.UtcNow.AddHours(-8),
+            Problems = problems
+
+        };
+
+        db.Contests.Add(contest);
+        await db.SaveChangesAsync();
+        foreach (var problem in problems)
+        {
+            await bus.Publish(new CoreJudge.Domain.Events.ProblemCreatedEvent
+            {
+                Difficulty = problem.Difficulty.ToString(),
+                ProblemId = problem.Id,
+                Title = problem.Name
+            });
+        }
+    }
+
+
+    //    static Problem ConstructProblem(Guid guid)
+    //    {
+    //        return new Problem
+    //        {
+    //            Name = "Sample Problem 1",
+    //            Description = "Write a function to find the maximum product of two words that have no common characters.",
+    //            Difficulty = Difficulty.Easy,
+    //            ProblemTopics = new List<ProblemTopic>
+    //                    {
+    //                        new ProblemTopic {
+    //                        Topic = new Topic
+    //                        {
+    //                            Name = "Bit Manipulation",
+    //                        }},
+    //                        new ProblemTopic {  Topic = new Topic
+    //                        {
+    //                            Name = "Arrays",
+    //                        }}
+    //                    },
+    //            MemoryLimit = Domain.Premitives.MemoryLimit.Lowest,
+    //            ProblemSetterId = guid,
+    //            RunTimeLimit = 1,
+    //            ContestPoints = Domain.Premitives.ContestPoints.Level14,
+
+    //            Testcases = new List<Testcase>
+    //                    {
+    //                        // Test case 1: Basic case with valid pair
+    //                        new Testcase
+    //                        {
+    //                            Input = "4\nabcd\nwxyz\nab\nxy\n",
+    //                            Output = "16"
+    //                        },
+
+    //                        // Test case 2: No valid pairs (all share characters)
+    //                        new Testcase
+    //                        {
+    //                            Input = "3\na\nab\nabc\n",
+    //                            Output = "0"
+    //                        },
+
+    //                        // Test case 3: Multiple valid pairs, return max
+    //                        new Testcase
+    //                        {
+    //                            Input = "5\nabc\ndef\nghi\nab\nxy\n",
+    //                            Output = "9"
+    //                        },
+
+    //                        // Test case 4: Single word (can't form pair)
+    //                        new Testcase
+    //                        {
+    //                            Input = "1\nhello\n",
+    //                            Output = "0"
+    //                        },
+
+    //                        // Test case 5: Large words
+    //                        new Testcase
+    //                        {
+    //                            Input = "4\nabcdefghij\nklmnopqrst\nabc\nklm\n",
+    //                            Output = "100"
+    //                        },
+
+    //                        // Test case 6: Words with common characters
+    //                        new Testcase
+    //                        {
+    //                            Input = "4\nabc\nbcd\ncde\ndef\n",
+    //                            Output = "9"
+    //                        },
+
+    //                        // Test case 7: Words with different lengths
+    //                        new Testcase
+    //                        {
+    //                            Input = "4\na\nbc\ndef\nghij\n",
+    //                            Output = "12"  // 
+    //                        }
+    //                    },
+
+    //            LanguagesTemplages = new List<ProblemLangeuageTemplates>
+    //                    {
+    //                        new ProblemLangeuageTemplates
+    //                {
+    //                    Language = Domain.Premitives.Language.cpp,
+    //                    StartingPoint = "// [USER_CODE_START]",
+    //                    UserCodeTemplate = @"class Solution {
+    //public:
+    //    int maxProduct(vector<string>& words) {
+    //        // Write your solution here
+
+    //    }
+    //};",
+    //                    UserCodeWrapper = @"#include <iostream>
+    //#include <vector>
+    //#include <string>
+    //#include <unordered_map>
+    //#include <algorithm>
+    //#include <bitset>
+    //using namespace std;
+
+    //// [USER_CODE_START]
+
+    //int main() {
+    //    int n;
+    //    cin >> n;
+    //    vector<string> words(n);
+    //    for(int i = 0; i < n; i++) {
+    //        cin >> words[i];
+    //    }
+
+    //    Solution sol;
+    //    int result = sol.maxProduct(words);
+    //    cout << result << endl;
+
+    //    return 0;
+    //}"
+    //                },
+    //                        new ProblemLangeuageTemplates
+    //                {
+    //                    Language = Domain.Premitives.Language.py,
+    //                    StartingPoint = "# [USER_CODE_START]",
+    //                    UserCodeTemplate = @"class Solution:
+    //                        def maxProduct(self, words: List[str]) -> int:
+    //                            # Write your solution here
+    //                            pass",
+    //                    UserCodeWrapper = @"from typing import List
+    //                    import sys
+
+    //                    # [USER_CODE_START]
+
+    //                    if __name__ == '__main__':
+    //                        n = int(sys.stdin.readline())
+    //                        words = []
+    //                        for _ in range(n):
+    //                            words.append(sys.stdin.readline().strip())
+
+    //                        sol = Solution()
+    //                        result = sol.maxProduct(words)
+    //                        print(result)"
+    //                                    },
+    //                        new ProblemLangeuageTemplates
+    //                                    {
+    //                                        Language = Domain.Premitives.Language.java,
+    //                                        StartingPoint = "// [USER_CODE_START]",
+    //                                        UserCodeTemplate = @"class Solution {
+    //                        public int maxProduct(String[] words) {
+    //                            // Write your solution here
+
+    //                        }
+    //                    }",
+    //                    UserCodeWrapper = @"import java.util.*;
+    //                                        import java.io.*;
+
+    //                                        // [USER_CODE_START]
+
+    //                                        public class Main {
+    //                                            public static void main(String[] args) throws Exception {
+    //                                                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    //                                                int n = Integer.parseInt(br.readLine());
+    //                                                String[] words = new String[n];
+    //                                                for(int i = 0; i < n; i++) {
+    //                                                    words[i] = br.readLine();
+    //                                                }
+
+    //                                                Solution sol = new Solution();
+    //                                                int result = sol.maxProduct(words);
+    //                                                System.out.println(result);
+    //                                            }
+    //                                        }"
+    //                }
+    //                    },
+
+    //            Submissions = new List<Submission>
+    //                    {
+    //                        new Submission
+    //                        {
+    //                            AttemperId = guid,
+    //                            Code = @"class Solution {
+    //                            public:
+    //                                int maxProduct(vector<string>& words) {
+    //                                    int n = words.size();
+    //                                    vector<int> masks(n, 0);
+
+    //                                    // Create bitmask for each word
+    //                                    for(int i = 0; i < n; i++) {
+    //                                        for(char c : words[i]) {
+    //                                            masks[i] |= 1 << (c - 'a');
+    //                                        }
+    //                                    }
+
+    //                                    // Find maximum product
+    //                                    int maxProduct = 0;
+    //                                    for(int i = 0; i < n; i++) {
+    //                                        for(int j = i + 1; j < n; j++) {
+    //                                            if((masks[i] & masks[j]) == 0) {
+    //                                                int product = words[i].length() * words[j].length();
+    //                                                maxProduct = max(maxProduct, product);
+    //                                            }
+    //                                        }
+    //                                    }
+
+    //                                    return maxProduct;
+    //                                }
+    //                            };",
+    //                            Language = Domain.Premitives.Language.cpp,
+    //                            Result = Domain.Premitives.SubmissionResult.Accepted,
+    //                            SubmissionDate = DateTime.UtcNow,
+    //                            SubmitMemory = 256,
+    //                            SubmitTime = 1000,
+    //                        }
+    //                    }
+    //        };
+
+    //    }
+
+    static List<Problem> ConstructProblems(Guid guid)
+    {
+        return new List<Problem>
+    {
+        // 1. TWO SUM
+        new Problem
+        {
+            Name = "Two Sum",
+            Description = "Find indices of two numbers that add up to a target.",
+            Difficulty = Difficulty.Easy,
+            ProblemSetterId = guid,
+            RunTimeLimit = 1,
+            Testcases = new List<Testcase>
+            {
+                new() { Input = "4\n2 7 11 15\n9\n", Output = "0 1\n" },
+                new() { Input = "3\n3 2 4\n6\n", Output = "1 2\n" },
+                new() { Input = "2\n3 3\n6\n", Output = "0 1\n" },
+                new() { Input = "4\n1 5 8 2\n10\n", Output = "2 3\n" },
+                new() { Input = "5\n-1 -2 -3 -4 -5\n-8\n", Output = "2 4\n" }
+            },
+            LanguagesTemplages = new List<ProblemLangeuageTemplates>
+            {
+                new() {
+                    Language = Domain.Premitives.Language.cpp,
+                    StartingPoint = "// [USER_CODE_START]",
+                    UserCodeTemplate = "class Solution {\npublic:\n    vector<int> twoSum(vector<int>& nums, int target) {\n        \n    }\n};",
+                    UserCodeWrapper = @"#include <iostream>
+                                        #include <vector>
+                                        #include <unordered_map>
+                                        using namespace std;
+                                        
+                                        // [USER_CODE_START]
+                                        
+                                        int main() {
+                                            int t;
+                                            if(!(cin >> t)) return 0;
+                                            while(t--) {
+                                                int n, target;
+                                                if(!(cin >> n)) break;
+                                                vector<int> nums(n);
+                                                for(int i = 0; i < n; i++) cin >> nums[i];
+                                                cin >> target;
+                                                Solution sol;
+                                                vector<int> res = sol.twoSum(nums, target);
+                                                if(res.size() >= 2) cout << res[0] << "" "" << res[1] << ""\n"";
+                                                cout << ""---DONE---"" << ""\n"";
+                                                cout.flush();
+                                            }
+                                            return 0;
+                                        }"
+                }
+            }
+        },
+
+        // 2. VALID PARENTHESES
+        new Problem
+        {
+            Name = "Valid Parentheses",
+            Description = "Determine if the input string of brackets is valid.",
+            Difficulty = Difficulty.Easy,
+            ProblemSetterId = guid,
+            RunTimeLimit = 1,
+            Testcases = new List<Testcase>
+            {
+                new() { Input = "()\n", Output = "true\n" },
+                new() { Input = "()[]{}\n", Output = "true\n" },
+                new() { Input = "(]\n", Output = "false\n" },
+                new() { Input = "([)]\n", Output = "false\n" },
+                new() { Input = "{[]}\n", Output = "true\n" }
+            },
+            LanguagesTemplages = new List<ProblemLangeuageTemplates>
+            {
+                new() {
+                    Language = Domain.Premitives.Language.cpp,
+                    StartingPoint = "// [USER_CODE_START]",
+                    UserCodeTemplate = "class Solution {\npublic:\n    bool isValid(string s) {\n        \n    }\n};",
+                    UserCodeWrapper = @"#include <iostream>
+                    #include <string>
+                    #include <stack>
+                    using namespace std;
+                    
+                    // [USER_CODE_START]
+                    
+                    int main() {
+                        int t;
+                        if(!(cin >> t)) return 0;
+                        while(t--) {
+                            string s;
+                            if(!(cin >> s)) break;
+                            Solution sol;
+                            cout << (sol.isValid(s) ? ""true"" : ""false"") << ""\n"";
+                            cout << ""---DONE---"" << ""\n"";
+                            cout.flush();
+                        }
+                        return 0;
+                    }"
+                }
+            }
+        },
+
+        // 3. REVERSE LIST
+        new Problem
+        {
+            Name = "Reverse List",
+            Description = "Reverse an array of integers.",
+            Difficulty = Difficulty.Easy,
+            ProblemSetterId = guid,
+            RunTimeLimit = 1,
+            Testcases = new List<Testcase>
+            {
+                new() { Input = "5\n1 2 3 4 5\n", Output = "5 4 3 2 1\n" },
+                new() { Input = "2\n1 2\n", Output = "2 1\n" },
+                new() { Input = "1\n10\n", Output = "10\n" },
+                new() { Input = "3\n0 0 1\n", Output = "1 0 0\n" },
+                new() { Input = "4\n11 22 33 44\n", Output = "44 33 22 11\n" }
+            },
+            LanguagesTemplages = new List<ProblemLangeuageTemplates>
+            {
+                new() {
+                    Language = Domain.Premitives.Language.cpp,
+                    StartingPoint = "// [USER_CODE_START]",
+                    UserCodeTemplate = "class Solution {\npublic:\n    vector<int> reverseList(vector<int>& nums) {\n        \n    }\n};",
+                    UserCodeWrapper = @"#include <iostream>
+                    #include <vector>
+                    using namespace std;
+                    
+                    // [USER_CODE_START]
+                    
+                    int main() {
+                        int t;
+                        if(!(cin >> t)) return 0;
+                        while(t--) {
+                            int n;
+                            if(!(cin >> n)) break;
+                            vector<int> v(n);
+                            for(int i = 0; i < n; i++) cin >> v[i];
+                            Solution sol;
+                            vector<int> res = sol.reverseList(v);
+                            for(int i = 0; i < res.size(); i++) {
+                                cout << res[i] << (i == res.size() - 1 ? """" : "" "");
+                            }
+                            cout << ""\n"";
+                            cout << ""---DONE---"" << ""\n"";
+                            cout.flush();
+                        }
+                        return 0;
+                    }"
+                }
+            }
+        }
+    };
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.API/Extentions/DataSeeding.cs
+++ b/src/Services/CoreJudge/CoreJudge.API/Extentions/DataSeeding.cs
@@ -17,8 +17,8 @@ public static class DataSeeding
 
         var Contests = await db.Contests.ToListAsync();
 
-        //if (Contests.Any())
-        //    return;
+        if (Contests.Any())
+            return;
         var problems = ConstructProblems(guid);
         var contest = new Contest
         {
@@ -259,9 +259,9 @@ public static class DataSeeding
     static List<Problem> ConstructProblems(Guid guid)
     {
         return new List<Problem>
-    {
-        // 1. TWO SUM
-        new Problem
+        {
+            // 1. TWO SUM
+            new Problem
         {
             Name = "Two Sum",
             Description = "Find indices of two numbers that add up to a target.",
@@ -309,9 +309,9 @@ public static class DataSeeding
                 }
             }
         },
-
-        // 2. VALID PARENTHESES
-        new Problem
+        
+            // 2. VALID PARENTHESES
+            new Problem
         {
             Name = "Valid Parentheses",
             Description = "Determine if the input string of brackets is valid.",
@@ -355,9 +355,9 @@ public static class DataSeeding
                 }
             }
         },
-
-        // 3. REVERSE LIST
-        new Problem
+        
+            // 3. REVERSE LIST
+            new Problem
         {
             Name = "Reverse List",
             Description = "Reverse an array of integers.",
@@ -406,6 +406,6 @@ public static class DataSeeding
                 }
             }
         }
-    };
+        };
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.API/Extentions/MigrationExtensions.cs
+++ b/src/Services/CoreJudge/CoreJudge.API/Extentions/MigrationExtensions.cs
@@ -3,31 +3,31 @@ using Microsoft.EntityFrameworkCore;
 
 namespace CoreJudge.API.Extentions;
 
-    public static class MigrationExtensions
+public static class MigrationExtensions
+{
+    public static async Task ApplyMigrationsWithRetryAsync(
+        this IServiceProvider services,
+        int retries = 5)
     {
-        public static async Task ApplyMigrationsWithRetryAsync(
-            this IServiceProvider services,
-            int retries = 5)
+        for (int i = 1; i <= retries; i++)
         {
-            for (int i = 1; i <= retries; i++)
+            try
             {
-                try
-                {
-                    using var scope = services.CreateScope();
-                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                using var scope = services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-                    await db.Database.MigrateAsync();
-                    Console.WriteLine("EF migrations applied");
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Migration attempt {i} failed: {ex.Message}");
-                    await Task.Delay(2000);
-                }
+                await db.Database.MigrateAsync();
+                Console.WriteLine("EF migrations applied");
+                return;
             }
-
-            throw new Exception("Failed to apply EF migrations");
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Migration attempt {i} failed: {ex.Message}");
+                await Task.Delay(2000);
+            }
         }
 
+        throw new Exception("Failed to apply EF migrations");
     }
+
+}

--- a/src/Services/CoreJudge/CoreJudge.API/Extentions/ScriptFileCleaner.cs
+++ b/src/Services/CoreJudge/CoreJudge.API/Extentions/ScriptFileCleaner.cs
@@ -1,0 +1,105 @@
+﻿using System.Text;
+
+namespace CoreJudge.API.Extentions;
+
+public static class ScriptFileCleaner
+{
+    // Plan / Pseudocode:
+    // 1. Validate that the file at 'path' exists; throw FileNotFoundException if it does not.
+    // 2. Read all bytes from the file asynchronously.
+    // 3. Try to decode bytes as UTF-8; if decoding fails, fall back to the system default encoding.
+    // 4. Remove any Unicode BOM character from the decoded content string.
+    // 5. Normalize line endings to LF-only by replacing CRLF and CR with LF.
+    // 6. If a shebang appears later in the file (index > 0), strip any leading content before the shebang.
+    // 7. Ensure the script starts with a shebang; if not, prefix with "#!/usr/bin/env bash\n".
+    // 8. Trim any leading whitespace.
+    // 9. Write the cleaned content back to the file without emitting a UTF-8 BOM.
+    // 10. Re-read the file bytes to verify that there is no BOM, CRLF, or stray BOM character.
+    // 11. If verification fails, collect and include the first few bytes in the exception message.
+    // 12. Log success to the console when cleaning completes.
+
+    /// <summary>
+    /// Cleans a script file to ensure it is UTF-8 without BOM and uses LF line endings,
+    /// guarantees a shebang at the top, and strips any leading garbage before the shebang.
+    /// </summary>
+    /// <param name="services">Service provider (unused, kept for extension method compatibility).</param>
+    /// <param name="path">Path to the script file to clean.</param>
+    public static async Task CleanScriptFile(this IServiceProvider services, string path)
+    {
+        // 1. Ensure file exists.
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Script not found at: {path}");
+
+        // 2. Read all bytes from the file.
+        byte[] bytes = await File.ReadAllBytesAsync(path);
+
+        string content;
+        try
+        {
+            // 3. Try decode as UTF-8 first.
+            content = Encoding.UTF8.GetString(bytes);
+        }
+        catch
+        {
+            // 3b. If decoding fails, fall back to the system default encoding.
+            content = Encoding.Default.GetString(bytes);
+        }
+
+        // 4. Remove any explicit Unicode BOM character (U+FEFF) from the string.
+        content = content.Replace("\uFEFF", "");
+
+        // 5. Normalize Windows CRLF and old Mac CR line endings to LF-only.
+        content = content.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        // 6. If a shebang occurs later in the file (index > 0),
+        //    remove any content that appears before it (common if metadata was prepended).
+        int shebangIndex = content.IndexOf("#!");
+        if (shebangIndex > 0)
+        {
+            content = content.Substring(shebangIndex);
+        }
+
+        // 7. Ensure the script starts with a shebang; if not, prepend a standard bash shebang.
+        if (!content.StartsWith("#!"))
+        {
+            content = "#!/usr/bin/env bash\n" + content;
+        }
+
+        // 8. Remove any leading whitespace that might precede the shebang after modifications.
+        content = content.TrimStart();
+
+        // 9. Write the cleaned content back to disk without emitting a UTF-8 BOM.
+        await File.WriteAllTextAsync(
+            path,
+            content,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+        );
+
+        // 10. Re-read the file bytes to verify the file has no BOM and uses LF-only.
+        byte[] verifyBytes = await File.ReadAllBytesAsync(path);
+
+        // 11. Detect BOM by checking the first three bytes for the UTF-8 BOM pattern 0xEF,0xBB,0xBF.
+        bool hasBom =
+            verifyBytes.Length >= 3 &&
+            verifyBytes[0] == 0xEF &&
+            verifyBytes[1] == 0xBB &&
+            verifyBytes[2] == 0xBF;
+
+        // Decode verification bytes as UTF-8 for content checks.
+        string verify = Encoding.UTF8.GetString(verifyBytes);
+
+        // 12. If there's still a BOM, CR characters, or stray FEFF characters, throw with diagnostics.
+        if (hasBom || verify.Contains('\r') || verify.Contains("\uFEFF"))
+        {
+            var firstBytes = string.Join(" ",
+                verifyBytes.Take(10).Select(b => b.ToString("X2")));
+
+            throw new InvalidOperationException(
+                $"Script still has BOM/CRLF after cleaning: {path}\nFirst bytes: {firstBytes}");
+        }
+
+        // 13. Log success so callers can see the operation completed.
+        Console.WriteLine("[startup] run_code.sh cleaned successfully — LF only, no BOM.");
+    }
+
+}

--- a/src/Services/CoreJudge/CoreJudge.API/Program.cs
+++ b/src/Services/CoreJudge/CoreJudge.API/Program.cs
@@ -1,18 +1,22 @@
-using BuildingBlocks.Core;
-using BuildingBlocks.Core.Exceptions.Handler;
+﻿using BuildingBlocks.Core;
 using BuildingBlocks.Core.Exceptions.Handler.BuildingBlocks.Core.Exceptions.Handler;
-using CoreJudge.API.Extentions;
-using CoreJudge.Application;
-using CoreJudge.Infrastructure;
 using BuildingBlocks.Identity;
 using BuildingBlocks.Logging;
+using CoreJudge.API.Extentions;
+using CoreJudge.Application;
+using CoreJudge.Domain.Premitives;
+using CoreJudge.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
-builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.Preserve;
+        options.JsonSerializerOptions.MaxDepth = 64;
+    });// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 
 builder.Services.AddSwaggerGen().AddSwaggerDocumentation();
@@ -26,6 +30,8 @@ builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
 var app = builder.Build();
 await app.Services.ApplyMigrationsWithRetryAsync();
+await app.Services.CleanScriptFile(Helper.ScriptFilePath);
+await app.Services.SeedDataAsync();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Repositories/IProblemRepository.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Repositories/IProblemRepository.cs
@@ -1,5 +1,6 @@
 ﻿
 using CoreJudge.Domain.Models;
+using CoreJudge.Domain.Premitives;
 
 namespace CodeSphere.Domain.Abstractions.Repositories
 {
@@ -11,7 +12,7 @@ namespace CodeSphere.Domain.Abstractions.Repositories
 
         int GetAcceptedProblemCount(int problemId, CancellationToken cancellationToken = default);
         int GetSubmissionsProblemCount(int problemId, CancellationToken cancellationToken = default);
-        Task<Problem?> GetProblemIncludingContestAndTestcases(int problemId);
+        Task<Problem?> GetProblemIncludingContestAndTestcases(int problemId, Language? language = null);
         bool CheckUserSolvedProblem(int problemId, string userId, CancellationToken cancellationToken = default);
 
     }

--- a/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Services/IExecutionService.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Services/IExecutionService.cs
@@ -7,7 +7,7 @@ namespace CodeSphere.Domain.Abstractions.Services
 {
     public interface IExecutionService
     {
-        Task<object> ExecuteCodeAsync(string code, Language language, List<Testcase> testCases, decimal runTimeLimit);
+        Task<object> ExecuteCodeAsync(string code, ProblemLangeuageTemplates template, Language language, List<Testcase> testCases, decimal runTimeLimit);
         //Task<object> ExecuteCodeAsync(string code, Language language, List<CustomTestcaseDto> testcases, decimal runTimeLimit);
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Services/IFileService.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Services/IFileService.cs
@@ -1,4 +1,5 @@
-﻿using CoreJudge.Domain.Premitives;
+﻿using CoreJudge.Domain.Models;
+using CoreJudge.Domain.Premitives;
 using Microsoft.AspNetCore.Http;
 
 namespace CodeSphere.Domain.Abstractions.Services
@@ -10,8 +11,8 @@ namespace CodeSphere.Domain.Abstractions.Services
         Task<string> UploadFileAsync(IFormFile file, string directory);
         Task<string> ReadFile(IFormFile file);
         Task<string> ReadFileAsync(string filePath);
-
-        Task<string> CreateTestCasesFile(string testCase, string requestDirectory);
-        Task<string> CreateCodeFile(string code, Language language, string requestDirectory);
+        Task CreateExpectedOutputFile(List<Testcase> testCases, string directory);
+        Task CreateTestCasesFile(List<Testcase> testCases, string directory);
+        Task<string> CreateCodeFile(string code, ProblemLangeuageTemplates template, Language language, string requestDirectory);
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Create/CreateProblemCommand.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Create/CreateProblemCommand.cs
@@ -1,7 +1,6 @@
 ﻿using BuildingBlocks.Core.CQRS;
 using CoreJudge.Domain.Models.Entities;
 using CoreJudge.Domain.Premitives;
-using MediatR;
 
 namespace CoreJudge.Application.Features.Problems.Commands.Create
 {
@@ -9,11 +8,21 @@ namespace CoreJudge.Application.Features.Problems.Commands.Create
     {
         public string Name { get; init; }
         public string Description { get; init; }
+        public List<ProblemCodeTemplate> CodeTemplate { get; init; }
         public int ContestId { get; init; }
         public Difficulty Difficulty { get; init; }
         public decimal RunTimeLimit { get; init; }
         public MemoryLimit MemoryLimit { get; init; }
         public IReadOnlyList<int> Topics { get; init; }
+
+    }
+
+    public record ProblemCodeTemplate
+    {
+        public string CodeWrapper { get; set; }
+        public string StartingPoint { get; set; }
+        public string CodeTemplate { get; set; }
+        public Language Language { get; set; }
 
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Create/CreateProblemCommandHandler.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Create/CreateProblemCommandHandler.cs
@@ -1,13 +1,10 @@
 using AutoMapper;
 using BuildingBlocks.Core.CQRS;
 using CodeSphere.Domain.Abstractions;
-using CodeSphere.Domain.Abstractions.Repositories;
-using CoreJudge.Application.Abstractions.Repositories;
+using CoreJudge.Domain.Events;
 using CoreJudge.Domain.Models;
 using CoreJudge.Domain.Premitives;
-using MediatR;
 using System.Net;
-using CoreJudge.Domain.Events;
 
 namespace CoreJudge.Application.Features.Problems.Commands.Create
 {
@@ -39,6 +36,14 @@ namespace CoreJudge.Application.Features.Problems.Commands.Create
             try
             {
                 var mappedProblem = mapper.Map<Domain.Models.Problem>(request);
+                mappedProblem.LanguagesTemplages = request.CodeTemplate.Select(t => new ProblemLangeuageTemplates
+                {
+                    Language = t.Language,
+                    StartingPoint = t.StartingPoint,
+                    UserCodeTemplate = t.CodeTemplate,
+                    UserCodeWrapper = t.CodeWrapper,
+
+                }).ToList();
 
                 await unitOfWork.Repository<Domain.Models.Problem>().AddAsync(mappedProblem);
                 //since we configured outbox by masstransit, it will intercept the publish network call and 

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Create/CreateProblemCommandValidator.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Create/CreateProblemCommandValidator.cs
@@ -11,19 +11,33 @@ namespace CoreJudge.Application.Features.Problems.Commands.Create
         {
             RuleFor(x => x.Name).NotEmpty().NotNull().MinimumLength(5).MaximumLength(30);
             RuleFor(x => x.Description).NotEmpty().NotNull().MinimumLength(10).MaximumLength(4000);
-			
+
             RuleFor(x => x.Difficulty)
-					   .NotNull()
-					   .WithMessage("Difficulty must not be null.") // Ensures it's not null
-					   .Must(value => Enum.IsDefined(typeof(Difficulty), value))
-					   .WithMessage("Difficulty must be one of the valid values: 0 (Easy), 1 (Medium), or 2 (Hard)."); RuleFor(x => x.ContestId).NotEmpty().NotNull();
+                       .NotNull()
+                       .WithMessage("Difficulty must not be null.") // Ensures it's not null
+                       .Must(value => Enum.IsDefined(typeof(Difficulty), value))
+                       .WithMessage("Difficulty must be one of the valid values: 0 (Easy), 1 (Medium), or 2 (Hard)."); RuleFor(x => x.ContestId).NotEmpty().NotNull();
             RuleFor(x => x.RunTimeLimit).NotNull();
-			
-			RuleFor(x => x.MemoryLimit)
-					   .NotNull()
-					   .WithMessage("MemoryLimit must not be null.") // Ensures it's not null
-					   .Must(value => Enum.IsDefined(typeof(MemoryLimit), value))
-					   .WithMessage("MemoryLimit must be one of the valid values: 16 (Lowest), 32 (Low), 64 (Medium), 128 (High), or 256 (Highest).");
-		}
+
+            RuleFor(x => x.MemoryLimit)
+                       .NotNull()
+                       .WithMessage("MemoryLimit must not be null.") // Ensures it's not null
+                       .Must(value => Enum.IsDefined(typeof(MemoryLimit), value))
+                       .WithMessage("MemoryLimit must be one of the valid values: 16 (Lowest), 32 (Low), 64 (Medium), 128 (High), or 256 (Highest).");
+
+
+            // validate the list of code templates, that it should contains atleast one template and do duplicate language temlates
+            RuleFor(x => x.CodeTemplate)
+                       .NotNull().WithMessage("Code templates are required")
+                       .Must(x => x != null && x.Any())
+                       .WithMessage("At least one code template is required")
+                       .Must(HaveNoDuplicateLanguages)
+                       .WithMessage("Duplicate language templates are not allowed");
+        }
+        private bool HaveNoDuplicateLanguages(List<ProblemCodeTemplate> templates)
+        {
+            if (templates == null) return true;
+            return templates.Select(t => t.Language).Distinct().Count() == templates.Count;
+        }
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Run/RunCodeCommandHandler.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Run/RunCodeCommandHandler.cs
@@ -2,7 +2,6 @@
 using CodeSphere.Domain.Abstractions;
 using CodeSphere.Domain.Abstractions.Services;
 using CoreJudge.Domain.Premitives;
-using MediatR;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 
@@ -31,7 +30,7 @@ namespace CoreJudge.Application.Features.Problems.Commands.Run
         }
         public async Task<Response> Handle(RunCodeCommand request, CancellationToken cancellationToken)
         {
-            var problem = await unitOfWork.ProblemRepository.GetProblemIncludingContestAndTestcases(request.ProblemId);
+            var problem = await unitOfWork.ProblemRepository.GetProblemIncludingContestAndTestcases(request.ProblemId, request.Language);
             if (problem == null)
                 return await Response.FailureAsync("Problem Not Found");
 

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Solve/SubmitSolutionCommandHandler.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Solve/SubmitSolutionCommandHandler.cs
@@ -3,8 +3,8 @@ using BuildingBlocks.Core.CQRS;
 using CodeSphere.Domain.Abstractions;
 using CodeSphere.Domain.Abstractions.Repositories;
 using CodeSphere.Domain.Abstractions.Services;
+using CoreJudge.Domain.Models;
 using CoreJudge.Domain.Premitives;
-using MediatR;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 
@@ -41,7 +41,7 @@ namespace CoreJudge.Application.Features.Problems.Commands.SolveProblem
         }
         public async Task<Response> Handle(SubmitSolutionCommand request, CancellationToken cancellationToken)
         {
-            var problem = await unitOfWork.ProblemRepository.GetProblemIncludingContestAndTestcases(request.ProblemId);
+            var problem = await unitOfWork.ProblemRepository.GetProblemIncludingContestAndTestcases(request.ProblemId, request.Language);
             if (problem == null)
                 return await Response.FailureAsync("Problem Not Found", System.Net.HttpStatusCode.NotFound);
 
@@ -59,24 +59,25 @@ namespace CoreJudge.Application.Features.Problems.Commands.SolveProblem
 
             string codeContent = await fileService.ReadFile(request.Code);
 
-            var result = await executionService.ExecuteCodeAsync(codeContent, request.Language, problem.Testcases.ToList(), problem.RunTimeLimit);
+            var result = await executionService.ExecuteCodeAsync(codeContent, problem.LanguagesTemplages.First(), request.Language, problem.Testcases.ToList(), problem.RunTimeLimit);
 
-            //var baseSubmissionResponse = (result as BaseSubmissionResponse);
-            //var acceptedSubmission = (result as AcceptedResponse);
-            //var compilationError = (result as CompilationErrorResponse);
-            //var submission = new Submit
-            //{
-            //    UserId = UserId,
-            //    SubmissionDate = DateTime.UtcNow,
-            //    ContestId = request.ContestId,
-            //    Language = request.Language,
-            //    Result = baseSubmissionResponse.SubmissionResult,
-            //    Error = (result as CompilationErrorResponse)?.Message ?? null,
-            //    ProblemId = request.ProblemId,
-            //    SubmitTime = acceptedSubmission?.ExecutionTime ?? null,
-            //    Code = codeContent,
-            //    SubmitMemory = 0m // TODO : implement memory usage in the shellscript
-            //};
+            var baseSubmissionResponse = (result as BaseSubmissionResponse);
+            var acceptedSubmission = (result as AcceptedResponse);
+            var compilationError = (result as CompilationErrorResponse);
+            var submission = new Submission
+            {
+                AttemperId = Guid.Parse(UserId),
+                SubmissionDate = DateTime.UtcNow,
+                ContestId = request.ContestId,
+                Language = request.Language,
+                Result = baseSubmissionResponse.SubmissionResult,
+                Error = (result as CompilationErrorResponse)?.Message ?? null,
+                ProblemId = request.ProblemId,
+                SubmitTime = acceptedSubmission?.ExecutionTime ?? null,
+                Code = codeContent,
+                SubmitMemory = 0m,
+
+            };
 
 
             //if (problem.Contest.ContestStatus == ContestStatus.Running)
@@ -107,13 +108,13 @@ namespace CoreJudge.Application.Features.Problems.Commands.SolveProblem
             //        Result = submission.Result
             //    }, UserId, submission.ContestId.Value);
             //}
-            //// insert the result in the database 
+            // insert the result in the database 
 
-            //await unitOfWork.Repository<Submit>().AddAsync(submission);
-            //await unitOfWork.CompleteAsync();
+            await unitOfWork.Repository<Submission>().AddAsync(submission);
+            await unitOfWork.CompleteAsync();
 
             // save submission result in database
-            return await Response.SuccessAsync(null, "Submitted Successfully", System.Net.HttpStatusCode.Created);
+            return await Response.SuccessAsync(result, "Submitted Successfully", System.Net.HttpStatusCode.Created);
         }
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Solve/SubmitSolutionCommandHandler.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Commands/Solve/SubmitSolutionCommandHandler.cs
@@ -73,7 +73,7 @@ namespace CoreJudge.Application.Features.Problems.Commands.SolveProblem
                 Result = baseSubmissionResponse.SubmissionResult,
                 Error = (result as CompilationErrorResponse)?.Message ?? null,
                 ProblemId = request.ProblemId,
-                SubmitTime = acceptedSubmission?.ExecutionTime ?? null,
+                MaxExecutionTimeMs = acceptedSubmission?.ExecutionTime ?? null,
                 Code = codeContent,
                 SubmitMemory = 0m,
 

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetById/GetProblemByIdQueryHandler.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetById/GetProblemByIdQueryHandler.cs
@@ -2,7 +2,6 @@
 using BuildingBlocks.Core.CQRS;
 using CodeSphere.Domain.Abstractions;
 using CoreJudge.Domain.Premitives;
-using MediatR;
 using Microsoft.AspNetCore.Http;
 using System.Net;
 using System.Security.Claims;

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Testcases/Commands/BulkCreate/BulkCreateTestcasesCommand.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Testcases/Commands/BulkCreate/BulkCreateTestcasesCommand.cs
@@ -1,0 +1,17 @@
+using BuildingBlocks.Core.CQRS;
+using CoreJudge.Domain.Premitives;
+
+namespace CoreJudge.Application.Features.TestCases.Commands.BulkCreate
+{
+    public class BulkCreateTestcasesCommand : ICommand<Response>
+    {
+        public int ProblemId { get; set; }
+        public List<TestcaseDto> Testcases { get; set; } = new();
+    }
+
+    public class TestcaseDto
+    {
+        public string Input { get; set; } = default!;
+        public string ExpectedOutput { get; set; } = default!;
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Testcases/Commands/BulkCreate/BulkCreateTestcasesCommandHandler.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Testcases/Commands/BulkCreate/BulkCreateTestcasesCommandHandler.cs
@@ -1,0 +1,41 @@
+using BuildingBlocks.Core.CQRS;
+using CodeSphere.Domain.Abstractions;
+using CoreJudge.Domain.Models;
+using CoreJudge.Domain.Premitives;
+
+namespace CoreJudge.Application.Features.TestCases.Commands.BulkCreate
+{
+    public class BulkCreateTestcasesCommandHandler : ICommandHandler<BulkCreateTestcasesCommand, Response>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public BulkCreateTestcasesCommandHandler(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<Response> Handle(BulkCreateTestcasesCommand request, CancellationToken cancellationToken)
+        {
+            var problem = await _unitOfWork.Repository<Domain.Models.Problem>().GetByIdAsync(request.ProblemId);
+            if (problem == null)
+                return await Response.FailureAsync("Problem not found!", System.Net.HttpStatusCode.NotFound);
+
+            if (request.Testcases == null || request.Testcases.Count == 0)
+                return await Response.FailureAsync("At least one testcase is required.", System.Net.HttpStatusCode.BadRequest);
+
+            var testcases = request.Testcases
+                .Select(tc => new Testcase(request.ProblemId, tc.Input, tc.ExpectedOutput))
+                .ToList();
+
+            foreach (var tc in testcases)
+                await _unitOfWork.Repository<Testcase>().AddAsync(tc);
+
+            await _unitOfWork.CompleteAsync();
+
+            return await Response.SuccessAsync(
+                new { count = testcases.Count },
+                $"{testcases.Count} testcase(s) added successfully.",
+                System.Net.HttpStatusCode.Created);
+        }
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Testcases/Commands/BulkCreate/BulkCreateTestcasesCommandValidator.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Testcases/Commands/BulkCreate/BulkCreateTestcasesCommandValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+
+namespace CoreJudge.Application.Features.TestCases.Commands.BulkCreate
+{
+    public class BulkCreateTestcasesCommandValidator : AbstractValidator<BulkCreateTestcasesCommand>
+    {
+        public BulkCreateTestcasesCommandValidator()
+        {
+            RuleFor(x => x.ProblemId)
+                .GreaterThan(0).WithMessage("ProblemId is required.");
+
+            RuleFor(x => x.Testcases)
+                .NotEmpty().WithMessage("At least one testcase is required.")
+                .Must(list => list.Count <= 500).WithMessage("Cannot add more than 500 testcases at once.");
+
+            RuleForEach(x => x.Testcases).ChildRules(tc =>
+            {
+                tc.RuleFor(t => t.Input)
+                    .NotEmpty().WithMessage("Testcase input is required.");
+
+                tc.RuleFor(t => t.ExpectedOutput)
+                    .NotEmpty().WithMessage("Testcase expected output is required.");
+            });
+        }
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Application/Mapping/ProblemProfile.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Mapping/ProblemProfile.cs
@@ -5,7 +5,6 @@ using CoreJudge.Application.Features.Problem.Common;
 using CoreJudge.Application.Features.Problems.Commands.Create;
 using CoreJudge.Application.Features.Problems.Queries.GetAll;
 using CoreJudge.Application.Features.Problems.Queries.GetById;
-using CoreJudge.Application.Mapping.Resolvers;
 using CoreJudge.Domain.Models;
 
 namespace CoreJudge.Application.Mapping;

--- a/src/Services/CoreJudge/CoreJudge.Application/Mapping/SubmissionProfile.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Mapping/SubmissionProfile.cs
@@ -12,7 +12,7 @@ public class SubmissionProfile : Profile
     {
         CreateMap<Submission, GetSubmissionDataQueryResponse>();
         CreateMap<Submission, GetProblemSubmissionsResponse>()
-            .ForMember(dest => dest.SubmitTime, opt => opt.MapFrom(src => src.SubmitTime))
+            .ForMember(dest => dest.SubmitTime, opt => opt.MapFrom(src => src.MaxExecutionTimeMs))
             .ForMember(dest => dest.SubmitMemory, opt => opt.MapFrom(src => src.SubmitMemory))
             .ForMember(dest => dest.Result, opt => opt.MapFrom(src => src.Result))
             .ForMember(dest => dest.SubmissionDate, opt => opt.MapFrom(src => src.SubmissionDate))
@@ -22,7 +22,7 @@ public class SubmissionProfile : Profile
 
         CreateMap<Submission, GetContestSubmissionsQueryResponse>()
             .ForMember(dest => dest.ProblemName, opt => opt.MapFrom(src => src.Problem.Name))
-            .ForMember(dest => dest.Time, opt => opt.MapFrom(src => src.SubmitTime))
+            .ForMember(dest => dest.Time, opt => opt.MapFrom(src => src.MaxExecutionTimeMs))
             .ForMember(dest => dest.Result, opt => opt.MapFrom(src => src.Result))
             .ForMember(dest => dest.SubmissionDate, opt => opt.MapFrom(src => src.SubmissionDate))
             .ForMember(dest => dest.Language, opt => opt.MapFrom(src => src.Language));

--- a/src/Services/CoreJudge/CoreJudge.Domain/Models/Problem.cs
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Models/Problem.cs
@@ -1,7 +1,6 @@
 ﻿using CoreJudge.Domain.Models.Entities;
 using CoreJudge.Domain.Premitives;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Reflection.Metadata;
 
 namespace CoreJudge.Domain.Models
 {
@@ -18,7 +17,6 @@ namespace CoreJudge.Domain.Models
         public string Description { get; set; } = default!;
         public ContestPoints ContestPoints { get; set; }
 
-
         [ForeignKey(nameof(ContestId))]
         public Contest Contest { get; set; } = default!;
         public ICollection<ProblemImage> Images { get; set; } = default!;
@@ -29,9 +27,6 @@ namespace CoreJudge.Domain.Models
 
         public ICollection<Submission> Submissions { get; set; } = default!;
 
-        //[ForeignKey(nameof(Blog))]
-        //public int? BlogId { get; set; }
-        //public Blog Blog { get; set; }
-
+        public ICollection<ProblemLangeuageTemplates> LanguagesTemplages { get; set; } = default!;
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Domain/Models/ProblemLangeuageTemplates.cs
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Models/ProblemLangeuageTemplates.cs
@@ -1,0 +1,18 @@
+﻿using CoreJudge.Domain.Premitives;
+
+namespace CoreJudge.Domain.Models
+{
+    public class ProblemLangeuageTemplates
+    {
+        public int Id { get; set; }
+        // Template for the user code, it will be used to generate the user code file and run it in the container
+        public string UserCodeTemplate { get; set; } = default!;
+        //wrapper for user code, create object from user class and call it's functon (if user changed the thier name) will break the code,
+        // get all testcases inputs one by one, call user function with passing input to it
+        public string UserCodeWrapper { get; set; } = default!;
+        public string StartingPoint { get; set; } = default!; // Starting point for setting user code class in the wrapper 
+        public Language Language { get; set; } = default!;
+        public int ProblemId { get; set; } = default!;
+        public Problem Problem { get; set; } = default!;
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Domain/Models/Submission.cs
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Models/Submission.cs
@@ -10,7 +10,7 @@ namespace CoreJudge.Domain.Models
         public int? ContestId { get; set; }
         public string? Error { get; set; }
         // the code execution time
-        public decimal? SubmitTime { get; set; }
+        public decimal? MaxExecutionTimeMs { get; set; }
         // the code execution memory
         public decimal? SubmitMemory { get; set; }
         public SubmissionResult Result { get; set; }

--- a/src/Services/CoreJudge/CoreJudge.Domain/Models/Testcase.cs
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Models/Testcase.cs
@@ -4,6 +4,10 @@ namespace CoreJudge.Domain.Models
 {
     public class Testcase : BaseEntity
     {
+        public Testcase()
+        {
+
+        }
         public Testcase(int problemId, string input, string output)
         {
             ProblemId = problemId;

--- a/src/Services/CoreJudge/CoreJudge.Domain/Premitives/CodeExecutionException.cs
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Premitives/CodeExecutionException.cs
@@ -1,0 +1,8 @@
+namespace CoreJudge.Domain.Premitives
+{
+    public class CodeExecutionException : Exception
+    {
+        public CodeExecutionException(string message) : base(message) { }
+        public CodeExecutionException(string message, Exception inner) : base(message, inner) { }
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Domain/Premitives/Helper.cs
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Premitives/Helper.cs
@@ -1,17 +1,16 @@
 ﻿
+using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Http;
 
 namespace CoreJudge.Domain.Premitives
 {
     public static class Helper
     {
         public static string ScriptFilePath;
-        public const string PythonCompiler = "python:3.8-slim";
-        public const string CppCompiler = "gcc:latest";
+        public const string PythonCompiler = "python:3.11-trixie";
+        public const string CppCompiler = "gcc:15-trixie";
         public const string CSharpCompiler = "mcr.microsoft.com/dotnet/sdk:5.0";
-        public const string ImagesDirectory = "UsersImages";
 
         public static string GenerateContestKey(int contestId)
         {
@@ -71,7 +70,7 @@ namespace CoreJudge.Domain.Premitives
             }
 
             // Combine solution path with the Infrastructure project path
-            string infrastructurePath = Path.Combine(directoryInfo.FullName, "CodeSphere.Domain", "Premitives", "run_code.sh");
+            string infrastructurePath = Path.Combine(directoryInfo.FullName, "Services", "CoreJudge", "CoreJudge.Domain", "Premitives", "run_code.sh");
 
 
             return infrastructurePath;

--- a/src/Services/CoreJudge/CoreJudge.Domain/Premitives/SubmissionResponses.cs
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Premitives/SubmissionResponses.cs
@@ -1,0 +1,47 @@
+namespace CoreJudge.Domain.Premitives
+{
+    /// <summary>
+    /// Base class for all submission result responses returned by the execution engine.
+    /// </summary>
+    public abstract class BaseSubmissionResponse
+    {
+        public SubmissionResult SubmissionResult { get; set; }
+        public int NumberOfPassedTestCases { get; set; }
+        public int TotalTestcases { get; set; }
+    }
+
+    public class AcceptedResponse : BaseSubmissionResponse
+    {
+        public AcceptedResponse() { SubmissionResult = SubmissionResult.Accepted; }
+        public decimal ExecutionTime { get; set; }
+    }
+
+    public class WrongAnswerResponse : BaseSubmissionResponse
+    {
+        public WrongAnswerResponse() { SubmissionResult = SubmissionResult.WrongAnswer; }
+        public string? Input { get; set; }
+        public string? ExpectedOutput { get; set; }
+        public string? ActualOutput { get; set; }
+    }
+
+    public class CompilationErrorResponse : BaseSubmissionResponse
+    {
+        public CompilationErrorResponse() { SubmissionResult = SubmissionResult.CompilationError; }
+        public string? Message { get; set; }
+    }
+
+    public class RunTimeErrorResponse : BaseSubmissionResponse
+    {
+        public RunTimeErrorResponse() { SubmissionResult = SubmissionResult.RunTimeError; }
+        public string? Message { get; set; }
+        public string? Input { get; set; }
+        public string? ExpectedOutput { get; set; }
+    }
+
+    public class TimeLimitExceedResponse : BaseSubmissionResponse
+    {
+        public TimeLimitExceedResponse() { SubmissionResult = SubmissionResult.TimeLimitExceeded; }
+        public string? Input { get; set; }
+        public string? ExpectedOutput { get; set; }
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Domain/Premitives/run_code.sh
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Premitives/run_code.sh
@@ -3,6 +3,7 @@
 # CONFIG
 # ------------------------
 CODE_DIR="/code"
+VERDICT_DIR="/tmp/verdict"
 TIMEOUT_PER_TESTCASE=${1:-5}
 SEPARATOR="---END---"
 OUTPUT_SENTINEL="---DONE---"
@@ -12,16 +13,17 @@ USER_PY="$CODE_DIR/main.py"
 USER_CS="$CODE_DIR/main.csproj"
 TESTCASES="$CODE_DIR/testcases.txt"
 EXPECTED="$CODE_DIR/expected.txt"
-OUTPUT_LOG="$CODE_DIR/output.txt"
-ERROR_LOG="$CODE_DIR/error.txt"
-RUNTIME_LOG="$CODE_DIR/runtime.txt"
-TLE_LOG="$CODE_DIR/tle.txt"
-FIFO_IN="$CODE_DIR/in.fifo"
-FIFO_OUT="$CODE_DIR/out.fifo"
+OUTPUT_LOG="$VERDICT_DIR/output.txt"
+ERROR_LOG="$VERDICT_DIR/error.txt"
+RUNTIME_LOG="$VERDICT_DIR/runtime.txt"
+TLE_LOG="$VERDICT_DIR/tle.txt"
+FIFO_IN="$VERDICT_DIR/in.fifo"
+FIFO_OUT="$VERDICT_DIR/out.fifo"
 
 # ------------------------
-# CLEAR OLD FILES
+# CREATE VERDICT DIR + CLEAR FILES
 # ------------------------
+mkdir -p "$VERDICT_DIR"
 : > "$OUTPUT_LOG"
 : > "$ERROR_LOG"
 : > "$RUNTIME_LOG"
@@ -30,47 +32,50 @@ FIFO_OUT="$CODE_DIR/out.fifo"
 # ------------------------
 # CLEANUP
 # ------------------------
-cleanup() {
-    kill "$PID" 2>/dev/null
+PID=""
+cleanup_and_exit() {
+    local exit_val=$1
+    [[ -n "$PID" ]] && kill "$PID" 2>/dev/null && wait "$PID" 2>/dev/null
+    exec 6>&- 2>/dev/null
+    exec 5<&- 2>/dev/null
     rm -f "$FIFO_IN" "$FIFO_OUT"
+    exit "$exit_val"
 }
-trap cleanup EXIT
+trap 'cleanup_and_exit 1' SIGTERM SIGINT
 
 # ------------------------
 # COMPILE / BUILD
 # ------------------------
 if [[ -f "$USER_CPP" ]]; then
-    g++ -O2 -std=c++17 -o "$CODE_DIR/main.out" "$USER_CPP" 2> "$ERROR_LOG"
+    g++ -O2 -std=c++17 -o "$VERDICT_DIR/main.out" "$USER_CPP" 2> "$ERROR_LOG"
     if [[ $? -ne 0 ]]; then
         echo "COMPILATIONFAILED" >> "$ERROR_LOG"
-        exit 1
+        cleanup_and_exit 1
     fi
-    EXEC_CMD="stdbuf -o0 $CODE_DIR/main.out"
+    EXEC_CMD="stdbuf -o0 $VERDICT_DIR/main.out"
 
 elif [[ -f "$USER_PY" ]]; then
     EXEC_CMD="python3 -u $USER_PY"
 
 elif [[ -f "$USER_CS" ]]; then
-    dotnet build "$USER_CS" -o "$CODE_DIR/output" 2>> "$ERROR_LOG"
+    dotnet build "$USER_CS" -o "$VERDICT_DIR/output" 2>> "$ERROR_LOG"
     if [[ $? -ne 0 ]]; then
         echo "BUILDFAILED" >> "$ERROR_LOG"
-        exit 1
+        cleanup_and_exit 1
     fi
-    EXEC_CMD="DOTNET_UNBUFFERED_IO=1 dotnet $CODE_DIR/output/main.dll"
+    EXEC_CMD="DOTNET_UNBUFFERED_IO=1 dotnet $VERDICT_DIR/output/main.dll"
 
 else
     echo "UNSUPPORTEDLANGUAGE" >> "$ERROR_LOG"
-    exit 1
+    cleanup_and_exit 1
 fi
 
 # ------------------------
 # FIFOS + LAUNCH PROGRAM ONCE
 # ------------------------
 mkfifo "$FIFO_IN" "$FIFO_OUT"
-
 eval "$EXEC_CMD" < "$FIFO_IN" > "$FIFO_OUT" 2>> "$ERROR_LOG" &
 PID=$!
-
 exec 6> "$FIFO_IN"
 exec 5< "$FIFO_OUT"
 
@@ -91,9 +96,7 @@ load_blocks() {
             block+="$line"$'\n'
         fi
     done < "$file"
-    if [[ -n "$block" ]]; then
-        arr+=("${block%$'\n'}")
-    fi
+    [[ -n "$block" ]] && arr+=("${block%$'\n'}")
 }
 
 declare -a testcase_blocks
@@ -101,24 +104,16 @@ declare -a expected_blocks
 load_blocks "$TESTCASES" testcase_blocks
 load_blocks "$EXPECTED"  expected_blocks
 
-# ------------------------
-# VALIDATE
-# ------------------------
 if [[ ${#testcase_blocks[@]} -ne ${#expected_blocks[@]} ]]; then
-    echo "TESTCASE_EXPECTED_MISMATCH: ${#testcase_blocks[@]} inputs vs ${#expected_blocks[@]} expected" >> "$ERROR_LOG"
-    exit 1
+    echo "TESTCASE_EXPECTED_MISMATCH" >> "$ERROR_LOG"
+    cleanup_and_exit 1
 fi
 
 total=${#testcase_blocks[@]}
-
-# ------------------------
-# SEND T FIRST
-# ------------------------
 printf '%s\n' "$total" >&6
 
 # ------------------------
 # READ UNTIL SENTINEL
-# Reads lines until ---DONE--- received or deadline hit
 # ------------------------
 read_until_sentinel() {
     local block=""
@@ -127,22 +122,18 @@ read_until_sentinel() {
 
     while true; do
         now=$(date +%s%3N)
-        if (( now >= deadline )); then
-            return 1
-        fi
+        (( now >= deadline )) && return 1
 
         remaining_ms=$(( deadline - now ))
-        remaining_sec_int=$(( remaining_ms / 1000 ))
-        remaining_sec_frac=$(( remaining_ms % 1000 ))
-        printf -v remaining_sec "%d.%03d" "$remaining_sec_int" "$remaining_sec_frac"
+        printf -v remaining_sec "%d.%03d" \
+            $(( remaining_ms / 1000 )) \
+            $(( remaining_ms % 1000 ))
 
         if IFS= read -u 5 -t "$remaining_sec" line; then
-            if [[ "$line" == "$OUTPUT_SENTINEL" ]]; then
-                break   # sentinel received — block complete
-            fi
+            [[ "$line" == "$OUTPUT_SENTINEL" ]] && break
             block+="$line"$'\n'
         else
-            return 1    # timeout without sentinel → TLE
+            return 1
         fi
     done
 
@@ -168,17 +159,18 @@ for (( i=0; i<total; i++ )); do
     elapsed=$(( end_ms - start_ms ))
 
     # TLE
-    if [[ $status -ne 0 ]]; then
+    if [[ $status -ne 0 ]] || (( elapsed > TIMEOUT_PER_TESTCASE * 1000 )); then
         {
             echo "TIMELIMITEXCEEDED"
             echo "Testcase: $((i+1))"
             echo "Passed: $PASSED"
             echo "Time consumed (ms): $elapsed"
+            echo "Time limit (ms): $(( TIMEOUT_PER_TESTCASE * 1000 ))"
         } >> "$TLE_LOG"
-        exit 1
+        cleanup_and_exit 1
     fi
 
-    # Log actual output — same delimiter as input/expected
+    # Log output
     {
         echo "$actual"
         echo "$SEPARATOR"
@@ -195,7 +187,7 @@ for (( i=0; i<total; i++ )); do
             echo "--- Got ---"
             echo "$actual"
         } >> "$RUNTIME_LOG"
-        exit 1
+        cleanup_and_exit 1
     fi
 
     PASSED=$(( PASSED + 1 ))
@@ -203,9 +195,8 @@ for (( i=0; i<total; i++ )); do
 done
 
 # ------------------------
-# CLEAN EXIT
+# FINAL VERDICT
 # ------------------------
-exec 6>&-
 wait "$PID" 2>/dev/null
 exit_code=$?
 
@@ -215,7 +206,8 @@ if [[ $exit_code -ne 0 ]]; then
         echo "Passed: $PASSED"
         echo "Exit code: $exit_code"
     } >> "$RUNTIME_LOG"
-    exit 1
+    cleanup_and_exit 1
 fi
 
 echo "ACCEPTED" >> "$RUNTIME_LOG"
+cleanup_and_exit 0

--- a/src/Services/CoreJudge/CoreJudge.Domain/Premitives/run_code.sh
+++ b/src/Services/CoreJudge/CoreJudge.Domain/Premitives/run_code.sh
@@ -1,54 +1,221 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
+# ------------------------
+# CONFIG
+# ------------------------
+CODE_DIR="/code"
+TIMEOUT_PER_TESTCASE=${1:-5}
+SEPARATOR="---END---"
+OUTPUT_SENTINEL="---DONE---"
 
-# Clear previous logs
-: > /code/output.txt
-: > /code/runtime.txt
-: > /code/error.txt
-: > /code/runtime_errors.txt
+USER_CPP="$CODE_DIR/main.cpp"
+USER_PY="$CODE_DIR/main.py"
+USER_CS="$CODE_DIR/main.csproj"
+TESTCASES="$CODE_DIR/testcases.txt"
+EXPECTED="$CODE_DIR/expected.txt"
+OUTPUT_LOG="$CODE_DIR/output.txt"
+ERROR_LOG="$CODE_DIR/error.txt"
+RUNTIME_LOG="$CODE_DIR/runtime.txt"
+TLE_LOG="$CODE_DIR/tle.txt"
+FIFO_IN="$CODE_DIR/in.fifo"
+FIFO_OUT="$CODE_DIR/out.fifo"
 
-# Timeout duration for each program
-TIMEOUT_DURATION=${1:-5s}
+# ------------------------
+# CLEAR OLD FILES
+# ------------------------
+: > "$OUTPUT_LOG"
+: > "$ERROR_LOG"
+: > "$RUNTIME_LOG"
+: > "$TLE_LOG"
 
-# Log runtime details and handle timeouts or runtime errors
-log_runtime_info() {
-    local exit_code=$1
-    local runtime_info="$2"
-    
-    if [[ $exit_code -eq 124 ]]; then
-        echo "TIMELIMITEXCEEDED" >> /code/runtime.txt
-    elif [[ $exit_code -eq 0 ]]; then
-        echo "$runtime_info" >> /code/runtime.txt
-    else
-        echo "RUNTIMEERROR: Program terminated with exit code $exit_code" >> /code/runtime_errors.txt
+# ------------------------
+# CLEANUP
+# ------------------------
+cleanup() {
+    kill "$PID" 2>/dev/null
+    rm -f "$FIFO_IN" "$FIFO_OUT"
+}
+trap cleanup EXIT
+
+# ------------------------
+# COMPILE / BUILD
+# ------------------------
+if [[ -f "$USER_CPP" ]]; then
+    g++ -O2 -std=c++17 -o "$CODE_DIR/main.out" "$USER_CPP" 2> "$ERROR_LOG"
+    if [[ $? -ne 0 ]]; then
+        echo "COMPILATIONFAILED" >> "$ERROR_LOG"
+        exit 1
+    fi
+    EXEC_CMD="stdbuf -o0 $CODE_DIR/main.out"
+
+elif [[ -f "$USER_PY" ]]; then
+    EXEC_CMD="python3 -u $USER_PY"
+
+elif [[ -f "$USER_CS" ]]; then
+    dotnet build "$USER_CS" -o "$CODE_DIR/output" 2>> "$ERROR_LOG"
+    if [[ $? -ne 0 ]]; then
+        echo "BUILDFAILED" >> "$ERROR_LOG"
+        exit 1
+    fi
+    EXEC_CMD="DOTNET_UNBUFFERED_IO=1 dotnet $CODE_DIR/output/main.dll"
+
+else
+    echo "UNSUPPORTEDLANGUAGE" >> "$ERROR_LOG"
+    exit 1
+fi
+
+# ------------------------
+# FIFOS + LAUNCH PROGRAM ONCE
+# ------------------------
+mkfifo "$FIFO_IN" "$FIFO_OUT"
+
+eval "$EXEC_CMD" < "$FIFO_IN" > "$FIFO_OUT" 2>> "$ERROR_LOG" &
+PID=$!
+
+exec 6> "$FIFO_IN"
+exec 5< "$FIFO_OUT"
+
+# ------------------------
+# LOAD BLOCKS
+# ------------------------
+load_blocks() {
+    local file="$1"
+    local -n arr="$2"
+    local block=""
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$line" == "$SEPARATOR" ]]; then
+            if [[ -n "$block" ]]; then
+                arr+=("${block%$'\n'}")
+            fi
+            block=""
+        else
+            block+="$line"$'\n'
+        fi
+    done < "$file"
+    if [[ -n "$block" ]]; then
+        arr+=("${block%$'\n'}")
     fi
 }
 
-# Execute the appropriate code based on file type
-if [[ -f "/code/main.py" ]]; then
-    # Run Python code
-    runtime_info=$( { time timeout $TIMEOUT_DURATION python3 /code/main.py < /code/testcases.txt > /code/output.txt; } 2>&1 )
-    log_runtime_info $? "$runtime_info"
+declare -a testcase_blocks
+declare -a expected_blocks
+load_blocks "$TESTCASES" testcase_blocks
+load_blocks "$EXPECTED"  expected_blocks
 
-elif [[ -f "/code/main.cpp" ]]; then
-    # Compile and run C++ code
-    g++ -o /code/main.out /code/main.cpp 2> /code/error.txt
-    if [[ $? -eq 0 ]]; then
-        runtime_info=$( { time timeout $TIMEOUT_DURATION /code/main.out < /code/testcases.txt > /code/output.txt; } 2>&1 )
-        log_runtime_info $? "$runtime_info"
-    else
-        echo "COMPILATIONFAILED" >> /code/error.txt
-    fi
-
-elif [[ -f "/code/main.cs" ]]; then
-    # Build and run C# code
-    dotnet build /code/main.csproj -o /code/output 2>> /code/error.txt
-    if [[ $? -eq 0 ]]; then
-        runtime_info=$( { time timeout $TIMEOUT_DURATION dotnet /code/output/main.dll < /code/testcases.txt > /code/output.txt; } 2>&1 )
-        log_runtime_info $? "$runtime_info"
-    else
-        echo "BUILDFAILED" >> /code/error.txt
-    fi
-
-else
-    echo "UNSUPPORTEDLANGUAGE" >> /code/error.txt
+# ------------------------
+# VALIDATE
+# ------------------------
+if [[ ${#testcase_blocks[@]} -ne ${#expected_blocks[@]} ]]; then
+    echo "TESTCASE_EXPECTED_MISMATCH: ${#testcase_blocks[@]} inputs vs ${#expected_blocks[@]} expected" >> "$ERROR_LOG"
+    exit 1
 fi
+
+total=${#testcase_blocks[@]}
+
+# ------------------------
+# SEND T FIRST
+# ------------------------
+printf '%s\n' "$total" >&6
+
+# ------------------------
+# READ UNTIL SENTINEL
+# Reads lines until ---DONE--- received or deadline hit
+# ------------------------
+read_until_sentinel() {
+    local block=""
+    local line
+    local deadline=$(( $(date +%s%3N) + TIMEOUT_PER_TESTCASE * 1000 ))
+
+    while true; do
+        now=$(date +%s%3N)
+        if (( now >= deadline )); then
+            return 1
+        fi
+
+        remaining_ms=$(( deadline - now ))
+        remaining_sec_int=$(( remaining_ms / 1000 ))
+        remaining_sec_frac=$(( remaining_ms % 1000 ))
+        printf -v remaining_sec "%d.%03d" "$remaining_sec_int" "$remaining_sec_frac"
+
+        if IFS= read -u 5 -t "$remaining_sec" line; then
+            if [[ "$line" == "$OUTPUT_SENTINEL" ]]; then
+                break   # sentinel received — block complete
+            fi
+            block+="$line"$'\n'
+        else
+            return 1    # timeout without sentinel → TLE
+        fi
+    done
+
+    printf '%s' "${block%$'\n'}"
+    return 0
+}
+
+# ------------------------
+# PROCESS TESTCASES
+# ------------------------
+PASSED=0
+
+for (( i=0; i<total; i++ )); do
+    input="${testcase_blocks[$i]}"
+    expected="${expected_blocks[$i]}"
+
+    printf '%s\n' "$input" >&6
+
+    start_ms=$(date +%s%3N)
+    actual=$(read_until_sentinel)
+    status=$?
+    end_ms=$(date +%s%3N)
+    elapsed=$(( end_ms - start_ms ))
+
+    # TLE
+    if [[ $status -ne 0 ]]; then
+        {
+            echo "TIMELIMITEXCEEDED"
+            echo "Testcase: $((i+1))"
+            echo "Passed: $PASSED"
+            echo "Time consumed (ms): $elapsed"
+        } >> "$TLE_LOG"
+        exit 1
+    fi
+
+    # Log actual output — same delimiter as input/expected
+    {
+        echo "$actual"
+        echo "$SEPARATOR"
+    } >> "$OUTPUT_LOG"
+
+    # Wrong answer
+    if [[ "$actual" != "$expected" ]]; then
+        {
+            echo "WRONG_ANSWER"
+            echo "Testcase: $((i+1))"
+            echo "Passed: $PASSED"
+            echo "--- Expected ---"
+            echo "$expected"
+            echo "--- Got ---"
+            echo "$actual"
+        } >> "$RUNTIME_LOG"
+        exit 1
+    fi
+
+    PASSED=$(( PASSED + 1 ))
+    echo "Testcase $((i+1)) time: ${elapsed}ms" >> "$RUNTIME_LOG"
+done
+
+# ------------------------
+# CLEAN EXIT
+# ------------------------
+exec 6>&-
+wait "$PID" 2>/dev/null
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+    {
+        echo "RUNTIMEERROR"
+        echo "Passed: $PASSED"
+        echo "Exit code: $exit_code"
+    } >> "$RUNTIME_LOG"
+    exit 1
+fi
+
+echo "ACCEPTED" >> "$RUNTIME_LOG"

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Context/ApplicationDbContext.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Context/ApplicationDbContext.cs
@@ -1,7 +1,7 @@
 using CoreJudge.Domain.Models;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using System.Reflection;
-using MassTransit;
 
 namespace CoreJudge.Infrastructure.Context
 {
@@ -14,6 +14,7 @@ namespace CoreJudge.Infrastructure.Context
         public DbSet<Testcase> Testcases { get; set; }
         public DbSet<Topic> Topics { get; set; }
         public DbSet<ProblemTopic> ProblemTopics { get; set; }
+        public DbSet<ProblemLangeuageTemplates> ProblemLangeuageTemplates { get; set; }
         public DbSet<Submission> Submissions { get; set; }
 
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Repositories/ProblemRepository.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Repositories/ProblemRepository.cs
@@ -35,13 +35,24 @@ namespace CoreJudge.Infrastructure.Implementation.Repositories
         => _context.Set<Testcase>().Where(x => x.ProblemId == problemId).AsNoTracking();
 
 
-        public async Task<Problem?> GetProblemIncludingContestAndTestcases(int problemId)
-          => await _context.Set<Problem>()
-                     .Include(p => p.Contest)
-                     .Include(p => p.Testcases)
-                     .AsNoTracking()
-                     .FirstOrDefaultAsync(p => p.Id == problemId);
+        public async Task<Problem?> GetProblemIncludingContestAndTestcases(int problemId, Language? language)
+        {
+            var query = _context.Set<Problem>()
+                .Include(p => p.Contest)
+                .Include(p => p.Testcases)
+                .AsQueryable();
 
-        
+            if (language != null)
+            {
+                query = query.Include(p => p.LanguagesTemplages
+                    .Where(t => t.Language == language));
+            }
+
+            return await query
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Id == problemId);
+        }
+
+
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Services/ExecutionService.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Services/ExecutionService.cs
@@ -3,6 +3,8 @@ using CodeSphere.Domain.Abstractions.Services;
 using CoreJudge.Domain.Models;
 using CoreJudge.Domain.Premitives;
 using Docker.DotNet;
+using Docker.DotNet.Models;
+using System.Text.RegularExpressions;
 
 
 namespace CodeSphere.Infrastructure.Implementation.Services
@@ -10,328 +12,285 @@ namespace CodeSphere.Infrastructure.Implementation.Services
     public class ExecutionService : IExecutionService
     {
         private readonly DockerClient _dockerClient;
+        private readonly IFileService fileService;
         private readonly IUnitOfWork unitOfWork;
         private string _requestDirectory = null;
         private string _containerId = null;
+
+        // the 4 files the shell script actually writes
         private string outputFile;
         private string errorFile;
-        private string runTimeFile;
-        private string runTimeErrorFile;
+        private string runtimeFile;
+        private string tleFile;
+
         public ExecutionService(IFileService fileService, IUnitOfWork unitOfWork)
         {
-            _dockerClient = new DockerClientConfiguration(new Uri("tcp://localhost:2375")).CreateClient();
+            _dockerClient = new DockerClientConfiguration(
+                new Uri("tcp://localhost:2375")).CreateClient();
+
             _requestDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(_requestDirectory);
+
             outputFile = Path.Combine(_requestDirectory, "output.txt");
             errorFile = Path.Combine(_requestDirectory, "error.txt");
-            runTimeFile = Path.Combine(_requestDirectory, "runtime.txt");
-            runTimeErrorFile = Path.Combine(_requestDirectory, "runtime_errors.txt");
+            runtimeFile = Path.Combine(_requestDirectory, "runtime.txt");
+            tleFile = Path.Combine(_requestDirectory, "tle.txt");
+
+            this.fileService = fileService;
             this.unitOfWork = unitOfWork;
         }
 
-        public Task<object> ExecuteCodeAsync(string code, Language language, List<Testcase> testCases, decimal runTimeLimit)
+        public async Task<object> ExecuteCodeAsync(string code, ProblemLangeuageTemplates template, Language language, List<Testcase> testCases, decimal runTimeLimit)
         {
-            throw new NotImplementedException();
+            await fileService.CreateCodeFile(code, template, language, _requestDirectory);
+
+
+            try
+            {
+                await CreateAndStartContainer(language);
+
+                // Write ALL testcases at once, delimited by ---END---
+                await fileService.CreateTestCasesFile(testCases, _requestDirectory);
+
+                // Write ALL expected outputs at once, same delimiter
+                await fileService.CreateExpectedOutputFile(testCases, _requestDirectory);
+
+                // Run the script ONCE
+                await ExecuteCodeInContainer(runTimeLimit);
+
+                // Read verdict from files
+                return await CalculateResult(testCases);
+            }
+            catch (Exception ex)
+            {
+                throw new CodeExecutionException("Error while running testcases.");
+            }
+            finally
+            {
+                if (Directory.Exists(_requestDirectory))
+                    Directory.Delete(_requestDirectory, true);
+
+                if (_containerId != null)
+                    await _dockerClient.Containers.RemoveContainerAsync(
+                        _containerId, new ContainerRemoveParameters { Force = true });
+            }
         }
-        //public async Task<object> ExecuteCodeAsync(string code, Language language, List<CustomTestcaseDto> testcases, decimal runTimeLimit)
-        //{
-        //    string path = await fileService.CreateCodeFile(code, language, _requestDirectory);
-        //    List<object> results = new();
-        //    try
-        //    {
-        //        // create container 
-        //        await CreateAndStartContainer(language);
+        private async Task<object> CalculateResult(List<Testcase> testCases)
+        {
+            int total = testCases.Count;
+            string error = await ReadFile(errorFile);
+            string runtime = await ReadFile(runtimeFile);
+            string tle = await ReadFile(tleFile);
 
+            // 1. Compilation failure
+            if (error.Contains("COMPILATIONFAILED") ||
+                error.Contains("BUILDFAILED") ||
+                error.Contains("UNSUPPORTEDLANGUAGE"))
+                return new CompilationErrorResponse
+                {
+                    Message = error,
+                    SubmissionResult = SubmissionResult.CompilationError,
+                    NumberOfPassedTestCases = 0,
+                    TotalTestcases = total
+                };
 
-        //        for (int i = 0; i < testcases.Count; i++)
-        //        {
+            // 2. TLE
+            if (tle.Contains("TIMELIMITEXCEEDED"))
+            {
+                int passed = ExtractPassed(tle);
+                var failedCase = testCases.ElementAtOrDefault(passed);
+                return new TimeLimitExceedResponse
+                {
+                    SubmissionResult = SubmissionResult.TimeLimitExceeded,
+                    NumberOfPassedTestCases = passed,
+                    TotalTestcases = total,
+                    Input = failedCase?.Input,
+                    ExpectedOutput = failedCase?.Output
+                };
+            }
 
-        //            await fileService.CreateTestCasesFile(testcases[i].Input, _requestDirectory);
+            // 3. Wrong answer
+            if (runtime.Contains("WRONG_ANSWER"))
+            {
+                int passed = ExtractPassed(runtime);
+                var (_, expected, got) = ParseWrongAnswer(runtime);
+                var failedCase = testCases.ElementAtOrDefault(passed);
+                return new WrongAnswerResponse
+                {
+                    SubmissionResult = SubmissionResult.WrongAnswer,
+                    NumberOfPassedTestCases = passed,
+                    TotalTestcases = total,
+                    ActualOutput = got,
+                    ExpectedOutput = expected,
+                    Input = failedCase?.Input
+                };
+            }
 
-        //            await ExecuteCodeInContainer(runTimeLimit);
+            // 4. Runtime error
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                int passed = ExtractPassed(runtime);
+                var failedCase = testCases.ElementAtOrDefault(passed);
+                return new RunTimeErrorResponse
+                {
+                    Message = error,
+                    SubmissionResult = SubmissionResult.RunTimeError,
+                    NumberOfPassedTestCases = passed,
+                    TotalTestcases = total,
+                    Input = failedCase?.Input,
+                    ExpectedOutput = failedCase?.Output
+                };
+            }
 
-        //            object result = await CalculateResult(testcases[i], i + 1, runTimeLimit, code, testcases.Count);
+            // 5. Accepted
+            if (runtime.Contains("ACCEPTED"))
+                return new AcceptedResponse
+                {
+                    SubmissionResult = SubmissionResult.Accepted,
+                    NumberOfPassedTestCases = total,
+                    TotalTestcases = total,
+                    ExecutionTime = ExtractMaxExecutionTime(runtime)
+                };
 
-        //            results.Add(result);
-        //        }
-        //        return results;
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        throw new CodeExecutionException("Error while running testcases !!!");
-        //    }
-        //    finally
-        //    {
-        //        if (Directory.Exists(_requestDirectory))
-        //        {
-        //            Directory.Delete(_requestDirectory, true);
-        //        }
+            throw new CodeExecutionException("Unrecognised verdict in runtime.txt");
+        }
 
-        //        if (_containerId != null)
-        //        {
-        //            await _dockerClient.Containers.RemoveContainerAsync(_containerId, new ContainerRemoveParameters { Force = true });
-        //        }
-        //    }
-        //}
+        private async Task CreateAndStartContainer(Language language)
+        {
+            var image = language switch
+            {
+                Language.py => Helper.PythonCompiler,
+                Language.cpp => Helper.CppCompiler,
+                Language.cs => Helper.CSharpCompiler,
+                _ => throw new ArgumentException("Unsupported language")
+            };
 
-        //private async Task<object> CalculateResult(CustomTestcaseDto testcaseDto, int testcaseNumber, decimal runTimeLimit, string code, int totalTestcases)
-        //{
-        //    string output = await fileService.ReadFileAsync(outputFile);
-        //    string error = await fileService.ReadFileAsync(errorFile);
-        //    string runTime = await fileService.ReadFileAsync(runTimeFile);
-        //    string runTimeError = await fileService.ReadFileAsync(runTimeErrorFile);
+            string scriptFilePath = Helper.ScriptFilePath;
 
+            var createContainerResponse = await _dockerClient.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                HostConfig = new HostConfig
+                {
+                    Binds = new[] { $"{_requestDirectory}:/code", $"{scriptFilePath}:/run_code.sh" },
+                    NetworkMode = "bridge",
+                    Memory = 256 * 1024 * 1024,
+                    AutoRemove = false
+                },
+                Image = image,
+                Cmd = new[] { "sh", "-c", "apt-get update && apt-get install -y time && tail -f /dev/null" }, // Install time package
 
-        //    BaseSubmissionResponse response = default;
+            });
 
-        //    if (!string.IsNullOrEmpty(error))
-        //    {
-        //        return new CompilationErrorResponse
-        //        {
-        //            Message = error,
-        //            SubmissionResult = SubmissionResult.CompilationError,
-        //            NumberOfPassedTestCases = 0,
-        //            TotalTestcases = totalTestcases
-        //        };
+            _containerId = createContainerResponse.ID;
+            await _dockerClient.Containers.StartContainerAsync(_containerId, new ContainerStartParameters());
+        }
 
-        //    }
+        private async Task ExecuteCodeInContainer(decimal timeLimit)
+        {
 
-        //    if (!string.IsNullOrEmpty(runTimeError))
-        //    {
-        //        return new RunTimeErrorResponse
-        //        {
-        //            Message = runTimeError,
-        //            SubmissionResult = SubmissionResult.RunTimeError,
-        //            Input = testcaseDto.Input,
-        //            TotalTestcases = totalTestcases,
-        //            NumberOfPassedTestCases = testcaseNumber - 1,
-        //            ExpectedOutput = testcaseDto.ExpectedOutput
+            ////// running the shell script to execute code and return output | Errors | etc.
+            //string command = Helper.CreateExecuteCodeCommand(_containerId, timeLimit);
 
-        //        };
-        //    }
+            //// Start the process to execute the command
+            ////docker exec b4a5525c894d6ea84e81f15b439d5aec8760882a39dd04e192e91335e74a8ca0 /usr/bin/bash /run_code.sh 1s
+            //using (var process = new System.Diagnostics.Process())
+            //{
+            //    process.StartInfo = new System.Diagnostics.ProcessStartInfo
+            //    {
+            //        FileName = "cmd.exe",
+            //        Arguments = $"/C {command}",
+            //        RedirectStandardOutput = true,
+            //        RedirectStandardError = true,
+            //        UseShellExecute = false,
+            //        CreateNoWindow = true
+            //    };
+            //    try
+            //    {
+            //        process.Start();
+            //        process.WaitForExit();
 
+            //    }
+            //    catch (Exception ex)
+            //    {
+            //        // Handle exceptions
+            //        throw new CodeExecutionException("Error While Executing Client Code !!");
+            //    }
+            //}
 
-        //    if (runTime?.Contains("TIMELIMITEXCEEDED") == true)
-        //    {
-        //        return new TimeLimitExceedResponse
-        //        {
-        //            Input = testcaseDto.Input,
-        //            NumberOfPassedTestCases = testcaseNumber - 1,
-        //            TotalTestcases = totalTestcases,
-        //            SubmissionResult = SubmissionResult.TimeLimitExceeded,
-        //            ExpectedOutput = testcaseDto.ExpectedOutput,
+            // Create the exec instance inside the already-running container
+            var execCreateResponse = await _dockerClient.Exec.ExecCreateContainerAsync(
+                _containerId,
+                new ContainerExecCreateParameters
+                {
+                    Cmd = new[] { "/usr/bin/bash", "/run_code.sh", timeLimit.ToString("F0") },
+                    AttachStdout = true,
+                    AttachStderr = true,
+                    Tty = false
+                }
+            );
 
-        //        };
-        //    }
+            // Attach and start
+            using var stream = await _dockerClient.Exec.StartAndAttachContainerExecAsync(
+                execCreateResponse.ID,
+                tty: false
+            );
 
-        //    if (output.TrimEnd('\n') != testcaseDto.ExpectedOutput.TrimEnd('\n'))
-        //    {
-        //        return new WrongAnswerResponse
-        //        {
-        //            NumberOfPassedTestCases = testcaseNumber - 1,
-        //            TotalTestcases = totalTestcases,
-        //            ActualOutput = output,
-        //            Input = testcaseDto.Input,
-        //            ExpectedOutput = testcaseDto.ExpectedOutput,
-        //            SubmissionResult = SubmissionResult.WrongAnswer,
-        //        };
-        //    }
+            // Outer timeout = 2× the per-testcase limit + 10s buffer for startup/compile
+            int outerTimeoutMs = (int)(timeLimit * 1000 * 2) + 10_000;
+            using var cts = new CancellationTokenSource(outerTimeoutMs);
 
-        //    return new AcceptedResponse
-        //    {
-        //        NumberOfPassedTestCases = testcaseNumber,
-        //        ExecutionTime = Helper.ExtractExecutionTime(runTime),
-        //        TotalTestcases = totalTestcases,
-        //    };
+            try
+            {
+                // This BLOCKS until the script fully exits — files are ready after this line
+                var (stdout, stderr) = await stream.ReadOutputToEndAsync(cts.Token);
 
-        //}
+                if (!string.IsNullOrWhiteSpace(stderr))
+                    await File.AppendAllTextAsync(errorFile, $"\n[docker exec stderr]: {stderr}");
+            }
+            catch (OperationCanceledException)
+            {
+                await File.AppendAllTextAsync(tleFile,
+                    $"TIMELIMITEXCEEDED\nTestcase: 1\nPassed: 0\nTime consumed (ms): {outerTimeoutMs}\n");
 
-        //public async Task<object> ExecuteCodeAsync(string code, Language language, List<Testcase> testCases, decimal runTimeLimit)
-        //{
-        //    string path = await fileService.CreateCodeFile(code, language, _requestDirectory);
-        //    decimal maxRunTime = 0m;
-        //    try
-        //    {
-        //        await CreateAndStartContainer(language);
+                throw new CodeExecutionException("Script execution timed out at container level.");
+            }
 
-        //        for (int i = 0; i < testCases.Count; i++)
-        //        {
-        //            await fileService.CreateTestCasesFile(testCases[i].Input, _requestDirectory);
+        }
 
-        //            // running the shell script to execute code and return output | Errors | etc.
-        //            await ExecuteCodeInContainer(runTimeLimit);
+        private async Task<string> ReadFile(string filepath)
+        {
+            if (!File.Exists(filepath)) return string.Empty;
+            return (await File.ReadAllTextAsync(filepath)).Trim();
+        }
 
-        //            var result = await CalculateResult(testCases[i], runTimeLimit, code, i + 1, testCases.Count);
+        private int ExtractPassed(string content)
+        {
+            var match = Regex.Match(content, @"Passed:\s*(\d+)");
+            return match.Success ? int.Parse(match.Groups[1].Value) : 0;
+        }
 
-        //            BaseSubmissionResponse baseResponse = result as BaseSubmissionResponse;
-        //            if (baseResponse.SubmissionResult != SubmissionResult.Accepted)
-        //                return result;
+        private decimal ExtractMaxExecutionTime(string runtime)
+        {
+            var matches = Regex.Matches(runtime, @"Testcase \d+ time: (\d+)ms");
+            if (!matches.Any()) return 0;
+            return matches.Max(m => decimal.Parse(m.Groups[1].Value));
+        }
 
-        //            AcceptedResponse response = new(baseResponse);
-        //            maxRunTime = Math.Max(maxRunTime, response.ExecutionTime);
-        //        }
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        throw new CodeExecutionException("Error while running testcases !!!");
-        //    }
-        //    finally
-        //    {
-        //        if (Directory.Exists(_requestDirectory))
-        //        {
-        //            Directory.Delete(_requestDirectory, true);
-        //        }
+        private (int testcaseNum, string expected, string got) ParseWrongAnswer(string runtime)
+        {
+            int num = 0;
+            var numMatch = Regex.Match(runtime, @"Testcase:\s*(\d+)");
+            if (numMatch.Success) int.TryParse(numMatch.Groups[1].Value, out num);
 
-        //        if (_containerId != null)
-        //        {
-        //            await _dockerClient.Containers.RemoveContainerAsync(_containerId, new ContainerRemoveParameters { Force = true });
-        //        }
-        //    }
+            var expMatch = Regex.Match(runtime, @"--- Expected ---\s*(.*?)\s*--- Got ---", RegexOptions.Singleline);
+            var gotMatch = Regex.Match(runtime, @"--- Got ---\s*(.*?)$", RegexOptions.Singleline);
 
-
-        //    return new AcceptedResponse
-        //    {
-        //        ExecutionTime = maxRunTime,
-        //        NumberOfPassedTestCases = testCases.Count,
-        //        TotalTestcases = testCases.Count
-        //    };
-
-        //}
-
-        ////TODO : use strategy patter instead of this function
-        //private async Task<object> CalculateResult(Testcase testCase, decimal runTimeLimit, string code, int testcaseNumber, int totalTestcases)
-        //{
-
-        //    string output = await fileService.ReadFileAsync(outputFile);
-        //    string error = await fileService.ReadFileAsync(errorFile);
-        //    string runTime = await fileService.ReadFileAsync(runTimeFile);
-        //    string runTimeError = await fileService.ReadFileAsync(runTimeErrorFile);
-
-
-        //    BaseSubmissionResponse response = default;
-
-        //    if (!string.IsNullOrEmpty(error))
-        //    {
-        //        return new CompilationErrorResponse
-        //        {
-        //            Message = error,
-        //            SubmissionResult = SubmissionResult.CompilationError,
-        //            NumberOfPassedTestCases = 0,
-        //            TotalTestcases = totalTestcases
-        //        };
-
-        //    }
-
-        //    if (!string.IsNullOrEmpty(runTimeError))
-        //    {
-        //        return new RunTimeErrorResponse
-        //        {
-        //            Message = runTimeError,
-        //            SubmissionResult = SubmissionResult.RunTimeError,
-        //            Input = testCase.Input,
-        //            TotalTestcases = totalTestcases,
-        //            NumberOfPassedTestCases = testcaseNumber - 1,
-        //            ExpectedOutput = testCase.Output
-
-        //        };
-        //    }
-
-        //    if (runTime?.Contains("TIMELIMITEXCEEDED") == true)
-        //    {
-        //        return new TimeLimitExceedResponse
-        //        {
-        //            Input = testCase.Input,
-        //            NumberOfPassedTestCases = testcaseNumber - 1,
-        //            TotalTestcases = totalTestcases,
-        //            SubmissionResult = SubmissionResult.TimeLimitExceeded,
-        //            ExpectedOutput = testCase.Output,
-
-        //        };
-        //    }
-
-        //    if (output.TrimEnd('\n') != testCase.Output.TrimEnd('\n'))
-        //    {
-        //        return new WrongAnswerResponse
-        //        {
-        //            NumberOfPassedTestCases = testcaseNumber - 1,
-        //            TotalTestcases = totalTestcases,
-        //            ActualOutput = output,
-        //            Input = testCase.Input,
-        //            ExpectedOutput = testCase.Output,
-        //            SubmissionResult = SubmissionResult.WrongAnswer,
-        //        };
-        //    }
-
-        //    return new AcceptedResponse
-        //    {
-        //        NumberOfPassedTestCases = testcaseNumber,
-        //        ExecutionTime = Helper.ExtractExecutionTime(runTime),
-        //        TotalTestcases = totalTestcases,
-        //    };
-        //}
-
-        //private async Task CreateAndStartContainer(Language language)
-        //{
-        //    var image = language switch
-        //    {
-        //        Language.py => Helper.PythonCompiler,
-        //        Language.cpp => Helper.CppCompiler,
-        //        Language.cs => Helper.CSharpCompiler,
-        //        _ => throw new ArgumentException("Unsupported language")
-        //    };
-
-        //    //string scriptFilePath = Helper.ScriptFilePath;
-
-        //    var createContainerResponse = await _dockerClient.Containers.CreateContainerAsync(new CreateContainerParameters
-        //    {
-        //        HostConfig = new HostConfig
-        //        {
-        //            Binds = new[] { $"{_requestDirectory}:/code", $"{Helper.ScriptFilePath}:/run_code.sh" },
-        //            NetworkMode = "bridge",
-        //            Memory = 256 * 1024 * 1024,
-        //            AutoRemove = false
-        //        },
-        //        Image = image,
-        //        Cmd = new[] { "sh", "-c", "apt-get update && apt-get install -y time && tail -f /dev/null" }, // Install time package
-
-        //    });
-
-        //    _containerId = createContainerResponse.ID;
-        //    await _dockerClient.Containers.StartContainerAsync(_containerId, new ContainerStartParameters());
-        //}
-
-        //private async Task ExecuteCodeInContainer(decimal timeLimit)
-        //{
-
-        //    // running the shell script to execute code and return output | Errors | etc.
-        //    string command = Helper.CreateExecuteCodeCommand(_containerId, timeLimit);
-
-        //    // Start the process to execute the command
-        //    using (var process = new System.Diagnostics.Process())
-        //    {
-        //        process.StartInfo = new System.Diagnostics.ProcessStartInfo
-        //        {
-        //            FileName = "cmd.exe",
-        //            Arguments = $"/C {command}",
-        //            RedirectStandardOutput = true,
-        //            RedirectStandardError = true,
-        //            UseShellExecute = false,
-        //            CreateNoWindow = true
-        //        };
-        //        try
-        //        {
-        //            process.Start();
-        //            process.WaitForExit();
-
-        //        }
-        //        catch (Exception ex)
-        //        {
-        //            // Handle exceptions
-        //            throw new CodeExecutionException("Error While Executing Client Code !!");
-        //        }
-        //    }
-        //}
-
+            return (
+                num,
+                expMatch.Success ? expMatch.Groups[1].Value.Trim() : string.Empty,
+                gotMatch.Success ? gotMatch.Groups[1].Value.Trim() : string.Empty
+            );
+        }
 
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Services/ExecutionService.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Services/ExecutionService.cs
@@ -1,296 +1,249 @@
-﻿using CodeSphere.Domain.Abstractions;
-using CodeSphere.Domain.Abstractions.Services;
+﻿using CodeSphere.Domain.Abstractions.Services;
 using CoreJudge.Domain.Models;
 using CoreJudge.Domain.Premitives;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using System.Text.RegularExpressions;
 
-
-namespace CodeSphere.Infrastructure.Implementation.Services
+public class ExecutionService : IExecutionService
 {
-    public class ExecutionService : IExecutionService
+    private readonly DockerClient _dockerClient;
+    private readonly IFileService fileService;
+    private string _requestDirectory = null;
+    private string _containerId = null;
+
+    public ExecutionService(IFileService fileService)
     {
-        private readonly DockerClient _dockerClient;
-        private readonly IFileService fileService;
-        private readonly IUnitOfWork unitOfWork;
-        private string _requestDirectory = null;
-        private string _containerId = null;
+        _dockerClient = new DockerClientConfiguration(
+            new Uri("tcp://localhost:2375")).CreateClient();
 
-        // the 4 files the shell script actually writes
-        private string outputFile;
-        private string errorFile;
-        private string runtimeFile;
-        private string tleFile;
+        _requestDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_requestDirectory);
+        this.fileService = fileService;
+    }
 
-        public ExecutionService(IFileService fileService, IUnitOfWork unitOfWork)
+    public async Task<object> ExecuteCodeAsync(
+        string code,
+        ProblemLangeuageTemplates template,
+        Language language,
+        List<Testcase> testCases,
+        decimal runTimeLimit)
+    {
+        // mounted to /code directory in container
+        await fileService.CreateCodeFile(code, template, language, _requestDirectory);
+        await fileService.CreateTestCasesFile(testCases, _requestDirectory);
+        await fileService.CreateExpectedOutputFile(testCases, _requestDirectory);
+
+        try
         {
-            _dockerClient = new DockerClientConfiguration(
-                new Uri("tcp://localhost:2375")).CreateClient();
-
-            _requestDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(_requestDirectory);
-
-            outputFile = Path.Combine(_requestDirectory, "output.txt");
-            errorFile = Path.Combine(_requestDirectory, "error.txt");
-            runtimeFile = Path.Combine(_requestDirectory, "runtime.txt");
-            tleFile = Path.Combine(_requestDirectory, "tle.txt");
-
-            this.fileService = fileService;
-            this.unitOfWork = unitOfWork;
+            await CreateAndStartContainer(language);
+            await ExecuteCodeInContainer(runTimeLimit, testCases.Count);
+            return await CalculateResult(testCases);
         }
-
-        public async Task<object> ExecuteCodeAsync(string code, ProblemLangeuageTemplates template, Language language, List<Testcase> testCases, decimal runTimeLimit)
+        catch (CodeExecutionException) { throw; }
+        catch (Exception)
         {
-            await fileService.CreateCodeFile(code, template, language, _requestDirectory);
-
-
-            try
-            {
-                await CreateAndStartContainer(language);
-
-                // Write ALL testcases at once, delimited by ---END---
-                await fileService.CreateTestCasesFile(testCases, _requestDirectory);
-
-                // Write ALL expected outputs at once, same delimiter
-                await fileService.CreateExpectedOutputFile(testCases, _requestDirectory);
-
-                // Run the script ONCE
-                await ExecuteCodeInContainer(runTimeLimit);
-
-                // Read verdict from files
-                return await CalculateResult(testCases);
-            }
-            catch (Exception ex)
-            {
-                throw new CodeExecutionException("Error while running testcases.");
-            }
-            finally
-            {
-                if (Directory.Exists(_requestDirectory))
-                    Directory.Delete(_requestDirectory, true);
-
-                if (_containerId != null)
-                    await _dockerClient.Containers.RemoveContainerAsync(
-                        _containerId, new ContainerRemoveParameters { Force = true });
-            }
+            throw new CodeExecutionException("Error while running testcases.");
         }
-        private async Task<object> CalculateResult(List<Testcase> testCases)
+        finally
         {
-            int total = testCases.Count;
-            string error = await ReadFile(errorFile);
-            string runtime = await ReadFile(runtimeFile);
-            string tle = await ReadFile(tleFile);
+            if (Directory.Exists(_requestDirectory))
+                Directory.Delete(_requestDirectory, true);
 
-            // 1. Compilation failure
-            if (error.Contains("COMPILATIONFAILED") ||
-                error.Contains("BUILDFAILED") ||
-                error.Contains("UNSUPPORTEDLANGUAGE"))
-                return new CompilationErrorResponse
-                {
-                    Message = error,
-                    SubmissionResult = SubmissionResult.CompilationError,
-                    NumberOfPassedTestCases = 0,
-                    TotalTestcases = total
-                };
-
-            // 2. TLE
-            if (tle.Contains("TIMELIMITEXCEEDED"))
-            {
-                int passed = ExtractPassed(tle);
-                var failedCase = testCases.ElementAtOrDefault(passed);
-                return new TimeLimitExceedResponse
-                {
-                    SubmissionResult = SubmissionResult.TimeLimitExceeded,
-                    NumberOfPassedTestCases = passed,
-                    TotalTestcases = total,
-                    Input = failedCase?.Input,
-                    ExpectedOutput = failedCase?.Output
-                };
-            }
-
-            // 3. Wrong answer
-            if (runtime.Contains("WRONG_ANSWER"))
-            {
-                int passed = ExtractPassed(runtime);
-                var (_, expected, got) = ParseWrongAnswer(runtime);
-                var failedCase = testCases.ElementAtOrDefault(passed);
-                return new WrongAnswerResponse
-                {
-                    SubmissionResult = SubmissionResult.WrongAnswer,
-                    NumberOfPassedTestCases = passed,
-                    TotalTestcases = total,
-                    ActualOutput = got,
-                    ExpectedOutput = expected,
-                    Input = failedCase?.Input
-                };
-            }
-
-            // 4. Runtime error
-            if (!string.IsNullOrWhiteSpace(error))
-            {
-                int passed = ExtractPassed(runtime);
-                var failedCase = testCases.ElementAtOrDefault(passed);
-                return new RunTimeErrorResponse
-                {
-                    Message = error,
-                    SubmissionResult = SubmissionResult.RunTimeError,
-                    NumberOfPassedTestCases = passed,
-                    TotalTestcases = total,
-                    Input = failedCase?.Input,
-                    ExpectedOutput = failedCase?.Output
-                };
-            }
-
-            // 5. Accepted
-            if (runtime.Contains("ACCEPTED"))
-                return new AcceptedResponse
-                {
-                    SubmissionResult = SubmissionResult.Accepted,
-                    NumberOfPassedTestCases = total,
-                    TotalTestcases = total,
-                    ExecutionTime = ExtractMaxExecutionTime(runtime)
-                };
-
-            throw new CodeExecutionException("Unrecognised verdict in runtime.txt");
+            if (_containerId != null)
+                await _dockerClient.Containers.RemoveContainerAsync(
+                    _containerId, new ContainerRemoveParameters { Force = true });
         }
+    }
 
-        private async Task CreateAndStartContainer(Language language)
+    private async Task CreateAndStartContainer(Language language)
+    {
+        var image = language switch
         {
-            var image = language switch
-            {
-                Language.py => Helper.PythonCompiler,
-                Language.cpp => Helper.CppCompiler,
-                Language.cs => Helper.CSharpCompiler,
-                _ => throw new ArgumentException("Unsupported language")
-            };
+            Language.py => Helper.PythonCompiler,
+            Language.cpp => Helper.CppCompiler,
+            Language.cs => Helper.CSharpCompiler,
+            _ => throw new ArgumentException("Unsupported language")
+        };
 
-            string scriptFilePath = Helper.ScriptFilePath;
+        string scriptFilePath = Helper.ScriptFilePath;
 
-            var createContainerResponse = await _dockerClient.Containers.CreateContainerAsync(new CreateContainerParameters
+        var createContainerResponse = await _dockerClient.Containers.CreateContainerAsync(
+            new CreateContainerParameters
             {
                 HostConfig = new HostConfig
                 {
-                    Binds = new[] { $"{_requestDirectory}:/code", $"{scriptFilePath}:/run_code.sh" },
+                    Binds = new[]
+                    {
+                        $"{_requestDirectory}:/code",
+                        $"{scriptFilePath}:/run_code.sh"
+                    },
                     NetworkMode = "bridge",
                     Memory = 256 * 1024 * 1024,
                     AutoRemove = false
                 },
                 Image = image,
-                Cmd = new[] { "sh", "-c", "apt-get update && apt-get install -y time && tail -f /dev/null" }, // Install time package
-
+                Cmd = new[] { "tail", "-f", "/dev/null" }  // no apt-get installs
             });
 
-            _containerId = createContainerResponse.ID;
-            await _dockerClient.Containers.StartContainerAsync(_containerId, new ContainerStartParameters());
-        }
+        _containerId = createContainerResponse.ID;
+        await _dockerClient.Containers.StartContainerAsync(
+            _containerId, new ContainerStartParameters());
+    }
 
-        private async Task ExecuteCodeInContainer(decimal timeLimit)
-        {
-
-            ////// running the shell script to execute code and return output | Errors | etc.
-            //string command = Helper.CreateExecuteCodeCommand(_containerId, timeLimit);
-
-            //// Start the process to execute the command
-            ////docker exec b4a5525c894d6ea84e81f15b439d5aec8760882a39dd04e192e91335e74a8ca0 /usr/bin/bash /run_code.sh 1s
-            //using (var process = new System.Diagnostics.Process())
-            //{
-            //    process.StartInfo = new System.Diagnostics.ProcessStartInfo
-            //    {
-            //        FileName = "cmd.exe",
-            //        Arguments = $"/C {command}",
-            //        RedirectStandardOutput = true,
-            //        RedirectStandardError = true,
-            //        UseShellExecute = false,
-            //        CreateNoWindow = true
-            //    };
-            //    try
-            //    {
-            //        process.Start();
-            //        process.WaitForExit();
-
-            //    }
-            //    catch (Exception ex)
-            //    {
-            //        // Handle exceptions
-            //        throw new CodeExecutionException("Error While Executing Client Code !!");
-            //    }
-            //}
-
-            // Create the exec instance inside the already-running container
-            var execCreateResponse = await _dockerClient.Exec.ExecCreateContainerAsync(
-                _containerId,
-                new ContainerExecCreateParameters
-                {
-                    Cmd = new[] { "/usr/bin/bash", "/run_code.sh", timeLimit.ToString("F0") },
-                    AttachStdout = true,
-                    AttachStderr = true,
-                    Tty = false
-                }
-            );
-
-            // Attach and start
-            using var stream = await _dockerClient.Exec.StartAndAttachContainerExecAsync(
-                execCreateResponse.ID,
-                tty: false
-            );
-
-            // Outer timeout = 2× the per-testcase limit + 10s buffer for startup/compile
-            int outerTimeoutMs = (int)(timeLimit * 1000 * 2) + 10_000;
-            using var cts = new CancellationTokenSource(outerTimeoutMs);
-
-            try
+    private async Task ExecuteCodeInContainer(decimal timeLimit, int testCaseCount)
+    {
+        var execCreateResponse = await _dockerClient.Exec.ExecCreateContainerAsync(
+            _containerId,
+            new ContainerExecCreateParameters
             {
-                // This BLOCKS until the script fully exits — files are ready after this line
-                var (stdout, stderr) = await stream.ReadOutputToEndAsync(cts.Token);
+                Cmd = new[] { "/usr/bin/bash", "/run_code.sh", timeLimit.ToString("F0") },
+                AttachStdout = true,
+                AttachStderr = true,
+                Tty = false
+            });
 
-                if (!string.IsNullOrWhiteSpace(stderr))
-                    await File.AppendAllTextAsync(errorFile, $"\n[docker exec stderr]: {stderr}");
-            }
-            catch (OperationCanceledException)
+        using var stream = await _dockerClient.Exec.StartAndAttachContainerExecAsync(
+            execCreateResponse.ID, tty: false);
+
+        // Total timeout = per-testcase limit × count + buffer for compile/startup
+        // to limit conatiner running time
+        int outerTimeoutMs = (int)(timeLimit * 1000 * testCaseCount) + 10_000;
+        using var cts = new CancellationTokenSource(outerTimeoutMs);
+
+        try
+        {
+            await stream.ReadOutputToEndAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            throw new CodeExecutionException("Script execution timed out at container level.");
+        }
+    }
+
+    private async Task<object> CalculateResult(List<Testcase> testCases)
+    {
+        int total = testCases.Count;
+
+        string error = await ReadContainerFile("error.txt");
+        string runtime = await ReadContainerFile("runtime.txt");
+        string tle = await ReadContainerFile("tle.txt");
+
+        if (error.Contains("COMPILATIONFAILED") ||
+            error.Contains("BUILDFAILED") ||
+            error.Contains("UNSUPPORTEDLANGUAGE"))
+            return new CompilationErrorResponse
             {
-                await File.AppendAllTextAsync(tleFile,
-                    $"TIMELIMITEXCEEDED\nTestcase: 1\nPassed: 0\nTime consumed (ms): {outerTimeoutMs}\n");
+                Message = error,
+                SubmissionResult = SubmissionResult.CompilationError,
+                NumberOfPassedTestCases = 0,
+                TotalTestcases = total
+            };
 
-                throw new CodeExecutionException("Script execution timed out at container level.");
-            }
-
-        }
-
-        private async Task<string> ReadFile(string filepath)
+        if (tle.Contains("TIMELIMITEXCEEDED"))
         {
-            if (!File.Exists(filepath)) return string.Empty;
-            return (await File.ReadAllTextAsync(filepath)).Trim();
+            int passed = ExtractPassed(tle);
+            var failedCase = testCases.ElementAtOrDefault(passed);
+            return new TimeLimitExceedResponse
+            {
+                SubmissionResult = SubmissionResult.TimeLimitExceeded,
+                NumberOfPassedTestCases = passed,
+                TotalTestcases = total,
+                Input = failedCase?.Input,
+                ExpectedOutput = failedCase?.Output
+            };
         }
 
-        private int ExtractPassed(string content)
+        if (runtime.Contains("WRONG_ANSWER"))
         {
-            var match = Regex.Match(content, @"Passed:\s*(\d+)");
-            return match.Success ? int.Parse(match.Groups[1].Value) : 0;
+            int passed = ExtractPassed(runtime);
+            var (_, expected, got) = ParseWrongAnswer(runtime);
+            var failedCase = testCases.ElementAtOrDefault(passed);
+            return new WrongAnswerResponse
+            {
+                SubmissionResult = SubmissionResult.WrongAnswer,
+                NumberOfPassedTestCases = passed,
+                TotalTestcases = total,
+                ActualOutput = got,
+                ExpectedOutput = expected,
+                Input = failedCase?.Input
+            };
         }
 
-        private decimal ExtractMaxExecutionTime(string runtime)
+        if (!string.IsNullOrWhiteSpace(error))
         {
-            var matches = Regex.Matches(runtime, @"Testcase \d+ time: (\d+)ms");
-            if (!matches.Any()) return 0;
-            return matches.Max(m => decimal.Parse(m.Groups[1].Value));
+            int passed = ExtractPassed(runtime);
+            var failedCase = testCases.ElementAtOrDefault(passed);
+            return new RunTimeErrorResponse
+            {
+                Message = error,
+                SubmissionResult = SubmissionResult.RunTimeError,
+                NumberOfPassedTestCases = passed,
+                TotalTestcases = total,
+                Input = failedCase?.Input,
+                ExpectedOutput = failedCase?.Output
+            };
         }
 
-        private (int testcaseNum, string expected, string got) ParseWrongAnswer(string runtime)
-        {
-            int num = 0;
-            var numMatch = Regex.Match(runtime, @"Testcase:\s*(\d+)");
-            if (numMatch.Success) int.TryParse(numMatch.Groups[1].Value, out num);
+        if (runtime.Contains("ACCEPTED"))
+            return new AcceptedResponse
+            {
+                SubmissionResult = SubmissionResult.Accepted,
+                NumberOfPassedTestCases = total,
+                TotalTestcases = total,
+                ExecutionTime = ExtractMaxExecutionTime(runtime)
+            };
 
-            var expMatch = Regex.Match(runtime, @"--- Expected ---\s*(.*?)\s*--- Got ---", RegexOptions.Singleline);
-            var gotMatch = Regex.Match(runtime, @"--- Got ---\s*(.*?)$", RegexOptions.Singleline);
+        throw new CodeExecutionException("Unrecognised verdict in runtime.txt");
+    }
 
-            return (
-                num,
-                expMatch.Success ? expMatch.Groups[1].Value.Trim() : string.Empty,
-                gotMatch.Success ? gotMatch.Groups[1].Value.Trim() : string.Empty
-            );
-        }
+    private async Task<string> ReadContainerFile(string filename)
+    {
+        var execResponse = await _dockerClient.Exec.ExecCreateContainerAsync(
+            _containerId,
+            new ContainerExecCreateParameters
+            {
+                Cmd = new[] { "cat", $"/tmp/verdict/{filename}" },
+                AttachStdout = true,
+                AttachStderr = true,
+                Tty = false
+            });
 
+        using var stream = await _dockerClient.Exec.StartAndAttachContainerExecAsync(
+            execResponse.ID, tty: false);
+
+        var (stdout, _) = await stream.ReadOutputToEndAsync(CancellationToken.None);
+        return stdout.Trim();
+    }
+
+    private int ExtractPassed(string content)
+    {
+        var match = Regex.Match(content, @"Passed:\s*(\d+)");
+        return match.Success ? int.Parse(match.Groups[1].Value) : 0;
+    }
+
+    private decimal ExtractMaxExecutionTime(string runtime)
+    {
+        var matches = Regex.Matches(runtime, @"Testcase \d+ time: (\d+)ms");
+        if (!matches.Any()) return 0;
+        return matches.Max(m => decimal.Parse(m.Groups[1].Value));
+    }
+
+    private (int testcaseNum, string expected, string got) ParseWrongAnswer(string runtime)
+    {
+        int num = 0;
+        var numMatch = Regex.Match(runtime, @"Testcase:\s*(\d+)");
+        if (numMatch.Success) int.TryParse(numMatch.Groups[1].Value, out num);
+
+        var expMatch = Regex.Match(runtime,
+            @"--- Expected ---\s*(.*?)\s*--- Got ---", RegexOptions.Singleline);
+        var gotMatch = Regex.Match(runtime,
+            @"--- Got ---\s*(.*?)$", RegexOptions.Singleline);
+
+        return (
+            num,
+            expMatch.Success ? expMatch.Groups[1].Value.Trim() : string.Empty,
+            gotMatch.Success ? gotMatch.Groups[1].Value.Trim() : string.Empty
+        );
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Services/FileService.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Services/FileService.cs
@@ -1,7 +1,9 @@
 ﻿using CodeSphere.Domain.Abstractions.Services;
+using CoreJudge.Domain.Models;
 using CoreJudge.Domain.Premitives;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using System.Text;
 
 namespace CodeSphere.Infrastructure.Implementation.Services
 {
@@ -33,16 +35,40 @@ namespace CodeSphere.Infrastructure.Implementation.Services
                => await System.IO.File.ReadAllTextAsync(filePath);
 
 
-        public async Task<string> CreateTestCasesFile(string testCase, string requestDirectory)
+        public async Task CreateTestCasesFile(List<Testcase> testCases, string directory)
         {
-            string testCasesPath = Path.Combine(requestDirectory, "testcases.txt");
-            await System.IO.File.WriteAllTextAsync(testCasesPath, testCase);
-            return testCasesPath;
+            var sb = new StringBuilder();
+            foreach (var tc in testCases)
+            {
+                sb.Append(tc.Input.TrimEnd().Replace("\r\n", "\n").Replace("\r", "\n"));
+                sb.Append("\n---END---\n");
+            }
+
+            await File.WriteAllTextAsync(
+                Path.Combine(directory, "testcases.txt"),
+                sb.ToString(),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         }
 
-        public async Task<string> CreateCodeFile(string code, Language language, string requestDirectory)
+        public async Task CreateExpectedOutputFile(List<Testcase> testCases, string directory)
         {
+            var sb = new StringBuilder();
+            foreach (var tc in testCases)
+            {
+                // Use \n explicitly — never AppendLine which writes \r\n on Windows
+                sb.Append(tc.Output.TrimEnd().Replace("\r\n", "\n").Replace("\r", "\n"));
+                sb.Append("\n---END---\n");
+            }
 
+            await File.WriteAllTextAsync(
+                Path.Combine(directory, "expected.txt"),
+                sb.ToString(),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+
+        public async Task<string> CreateCodeFile(string code, ProblemLangeuageTemplates template, Language language, string requestDirectory)
+        {
+            code = template.UserCodeWrapper.Replace(template.StartingPoint, code);
             string testCasesPath = Path.Combine(requestDirectory, $"main.{language.ToString()}");
 
             await System.IO.File.WriteAllTextAsync(testCasesPath, code);

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403134614_AddProblemWrapperAndTemplate.Designer.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403134614_AddProblemWrapperAndTemplate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoreJudge.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoreJudge.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403134614_AddProblemWrapperAndTemplate")]
+    partial class AddProblemWrapperAndTemplate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -82,6 +85,14 @@ namespace CoreJudge.Infrastructure.Migrations
                     b.Property<decimal>("RunTimeLimit")
                         .HasColumnType("numeric");
 
+                    b.Property<string>("UserCodeTemplate")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UserCodeWrapper")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.HasKey("Id");
 
                     b.HasIndex("ContestId");
@@ -109,39 +120,6 @@ namespace CoreJudge.Infrastructure.Migrations
                     b.HasIndex("ProblemId");
 
                     b.ToTable("ProblemImages");
-                });
-
-            modelBuilder.Entity("CoreJudge.Domain.Models.ProblemLangeuageTemplates", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("Language")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("ProblemId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartingPoint")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("UserCodeTemplate")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("UserCodeWrapper")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ProblemId");
-
-                    b.ToTable("ProblemLangeuageTemplates");
                 });
 
             modelBuilder.Entity("CoreJudge.Domain.Models.ProblemTopic", b =>
@@ -460,17 +438,6 @@ namespace CoreJudge.Infrastructure.Migrations
                     b.Navigation("Problem");
                 });
 
-            modelBuilder.Entity("CoreJudge.Domain.Models.ProblemLangeuageTemplates", b =>
-                {
-                    b.HasOne("CoreJudge.Domain.Models.Problem", "Problem")
-                        .WithMany("LanguagesTemplages")
-                        .HasForeignKey("ProblemId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Problem");
-                });
-
             modelBuilder.Entity("CoreJudge.Domain.Models.ProblemTopic", b =>
                 {
                     b.HasOne("CoreJudge.Domain.Models.Problem", "Problem")
@@ -542,8 +509,6 @@ namespace CoreJudge.Infrastructure.Migrations
             modelBuilder.Entity("CoreJudge.Domain.Models.Problem", b =>
                 {
                     b.Navigation("Images");
-
-                    b.Navigation("LanguagesTemplages");
 
                     b.Navigation("ProblemTopics");
 

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403134614_AddProblemWrapperAndTemplate.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403134614_AddProblemWrapperAndTemplate.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoreJudge.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProblemWrapperAndTemplate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UserCodeTemplate",
+                table: "Problems",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "UserCodeWrapper",
+                table: "Problems",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UserCodeTemplate",
+                table: "Problems");
+
+            migrationBuilder.DropColumn(
+                name: "UserCodeWrapper",
+                table: "Problems");
+        }
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144235_AddStartingPoint.Designer.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144235_AddStartingPoint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoreJudge.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoreJudge.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403144235_AddStartingPoint")]
+    partial class AddStartingPoint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -82,6 +85,18 @@ namespace CoreJudge.Infrastructure.Migrations
                     b.Property<decimal>("RunTimeLimit")
                         .HasColumnType("numeric");
 
+                    b.Property<string>("StartingPoint")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UserCodeTemplate")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UserCodeWrapper")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.HasKey("Id");
 
                     b.HasIndex("ContestId");
@@ -109,39 +124,6 @@ namespace CoreJudge.Infrastructure.Migrations
                     b.HasIndex("ProblemId");
 
                     b.ToTable("ProblemImages");
-                });
-
-            modelBuilder.Entity("CoreJudge.Domain.Models.ProblemLangeuageTemplates", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("Language")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("ProblemId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartingPoint")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("UserCodeTemplate")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("UserCodeWrapper")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ProblemId");
-
-                    b.ToTable("ProblemLangeuageTemplates");
                 });
 
             modelBuilder.Entity("CoreJudge.Domain.Models.ProblemTopic", b =>
@@ -460,17 +442,6 @@ namespace CoreJudge.Infrastructure.Migrations
                     b.Navigation("Problem");
                 });
 
-            modelBuilder.Entity("CoreJudge.Domain.Models.ProblemLangeuageTemplates", b =>
-                {
-                    b.HasOne("CoreJudge.Domain.Models.Problem", "Problem")
-                        .WithMany("LanguagesTemplages")
-                        .HasForeignKey("ProblemId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Problem");
-                });
-
             modelBuilder.Entity("CoreJudge.Domain.Models.ProblemTopic", b =>
                 {
                     b.HasOne("CoreJudge.Domain.Models.Problem", "Problem")
@@ -542,8 +513,6 @@ namespace CoreJudge.Infrastructure.Migrations
             modelBuilder.Entity("CoreJudge.Domain.Models.Problem", b =>
                 {
                     b.Navigation("Images");
-
-                    b.Navigation("LanguagesTemplages");
 
                     b.Navigation("ProblemTopics");
 

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144235_AddStartingPoint.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144235_AddStartingPoint.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoreJudge.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStartingPoint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "StartingPoint",
+                table: "Problems",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StartingPoint",
+                table: "Problems");
+        }
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144945_AddProblemLanguageTemplatesTable.Designer.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144945_AddProblemLanguageTemplatesTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoreJudge.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoreJudge.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403144945_AddProblemLanguageTemplatesTable")]
+    partial class AddProblemLanguageTemplatesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144945_AddProblemLanguageTemplatesTable.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260403144945_AddProblemLanguageTemplatesTable.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CoreJudge.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProblemLanguageTemplatesTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StartingPoint",
+                table: "Problems");
+
+            migrationBuilder.DropColumn(
+                name: "UserCodeTemplate",
+                table: "Problems");
+
+            migrationBuilder.DropColumn(
+                name: "UserCodeWrapper",
+                table: "Problems");
+
+            migrationBuilder.CreateTable(
+                name: "ProblemLangeuageTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserCodeTemplate = table.Column<string>(type: "text", nullable: false),
+                    UserCodeWrapper = table.Column<string>(type: "text", nullable: false),
+                    StartingPoint = table.Column<string>(type: "text", nullable: false),
+                    Language = table.Column<int>(type: "integer", nullable: false),
+                    ProblemId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProblemLangeuageTemplates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProblemLangeuageTemplates_Problems_ProblemId",
+                        column: x => x.ProblemId,
+                        principalTable: "Problems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProblemLangeuageTemplates_ProblemId",
+                table: "ProblemLangeuageTemplates",
+                column: "ProblemId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProblemLangeuageTemplates");
+
+            migrationBuilder.AddColumn<string>(
+                name: "StartingPoint",
+                table: "Problems",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "UserCodeTemplate",
+                table: "Problems",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "UserCodeWrapper",
+                table: "Problems",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/src/Services/Users/User.API/Services/Implementation/UserService.cs
+++ b/src/Services/Users/User.API/Services/Implementation/UserService.cs
@@ -1,12 +1,7 @@
-using System.Text.Json;
 using BuildingBlocks.Core.Exceptions;
-using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.SignalR;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Users.API.Domain.Models;
 using Users.API.Feature.User;
-using Users.API.Feature.User.Common;
 using Users.API.Infrastructure.Repository.Abstractions;
 using Users.API.Services.Abstraction;
 
@@ -78,36 +73,31 @@ public class UserService(IJwtTokenGenerator _tokenGenerator,
             user.IsPublicProfile,
             user.ProfilePictureUrl
         );
-        
+
     }
 
     public async Task<Login.LoginUserResponse> LoginUserAsync(Login.LoginUserRequestDto loginUserRequestDto, CancellationToken cancellationToken = default)
     {
-        var users =  userManager.Users.ToList();
-        Console.WriteLine("loginUserRequestDto");
-        Console.WriteLine(JsonSerializer.Serialize(loginUserRequestDto));
-        Console.WriteLine("All Users");
-        Console.WriteLine(JsonSerializer.Serialize(users));
         var user = await userManager.FindByEmailAsync(loginUserRequestDto.Email);
 
-         if (user is null)
-             throw new UnAuthorizedException("Invalid credentials");
+        if (user is null)
+            throw new UnAuthorizedException("Invalid credentials");
 
-         var result = await signInManager.CheckPasswordSignInAsync(
-             user,
-             loginUserRequestDto.Password,
-             lockoutOnFailure: true);
+        var result = await signInManager.CheckPasswordSignInAsync(
+            user,
+            loginUserRequestDto.Password,
+            lockoutOnFailure: true);
 
-         if (!result.Succeeded)
-             throw new UnAuthorizedException("Invalid credentials");
+        if (!result.Succeeded)
+            throw new UnAuthorizedException("Invalid credentials");
 
-         user.LastLogin = DateTime.UtcNow;
-         await userManager.UpdateAsync(user);
+        user.LastLogin = DateTime.UtcNow;
+        await userManager.UpdateAsync(user);
 
-         var accessToken = await _tokenGenerator.GenerateTokenAsync(user);
-         // var refreshToken = await jwtTokenGenerator.GenerateRefreshTokenAsync(user);
+        var accessToken = await _tokenGenerator.GenerateTokenAsync(user);
+        // var refreshToken = await jwtTokenGenerator.GenerateRefreshTokenAsync(user);
 
-         return new Login.LoginUserResponse(accessToken);
+        return new Login.LoginUserResponse(accessToken);
     }
     public async Task UpdateUserAsync(UpdateUser.UpdateUserDto updateUserDto, Guid userId, CancellationToken cancellationToken = default)
     {
@@ -128,7 +118,7 @@ public class UserService(IJwtTokenGenerator _tokenGenerator,
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
     }
-    
+
     public async Task AddRoleToUserAsync(Guid userId, string role, CancellationToken cancellationToken = default)
     {
         var user = await userManager.FindByIdAsync(userId.ToString());

--- a/src/out.txt
+++ b/src/out.txt
@@ -1,2 +1,0 @@
-MSBUILD : error MSB1009: Project file does not exist.
-Switch:  Services\CoreJudge\CoreJudge.Application\CoreJudge.Application.csproj


### PR DESCRIPTION
Edited code execution flow to run user code as a singleton process, so it doesn't restart after each testcase execution.  
Added database tables for every problem template and its wrapper code.  
Removed mounting of files created by the shell script to the host, and now they are read directly from the container files inside the verdict directory.

| Host `_requestDirectory/` | Container `/code/` | Container `/tmp/verdict/` |
|---------------------------|------------------|---------------------------|
| main.cpp (mounted) →      | main.cpp          |                           |
| main.py (mounted) →       | main.py           |                           |
| testcases.txt (mounted) → | testcases.txt     |                           |
| expected.txt (mounted) →  | expected.txt      |                           |
|                           |                  | error.txt ← here          |
|                           |                  | runtime.txt ← here        |
|                           |                  | tle.txt ← here            |
|                           |                  | output.txt ← here         |
|                           |                  | main.out ← here           |