### PR TITLE
Add API for problem code placeholders & rename SubmitTime

### DIFF
--- a/src/Services/CoreJudge/CoreJudge.API/Controllers/ProblemsController.cs
+++ b/src/Services/CoreJudge/CoreJudge.API/Controllers/ProblemsController.cs
@@ -1,5 +1,6 @@
 ﻿
 using BuildingBlocks.Identity;
+using CoreJudge.Application.Features.Problem.Queries.GetProblemLanguagesPlaceHolders;
 using CoreJudge.Application.Features.Problems.Commands.Create;
 using CoreJudge.Application.Features.Problems.Commands.Delete;
 using CoreJudge.Application.Features.Problems.Commands.Run;
@@ -69,5 +70,8 @@ namespace CoreJudge.API.Controllers
                 order);
             return ResponseResult(await mediator.Send(query));
         }
+        [HttpGet("problem-placeholders/{problemId}")]
+        public async Task<ActionResult<Response>> GetProblemPlaceHolders([FromRoute] int problemId)
+          => ResponseResult(await mediator.Send(new GetProblemLanguagesPlaceholdersQuery(problemId)));
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Repositories/IProblemRepository.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Abstractions/Repositories/IProblemRepository.cs
@@ -14,6 +14,7 @@ namespace CodeSphere.Domain.Abstractions.Repositories
         int GetSubmissionsProblemCount(int problemId, CancellationToken cancellationToken = default);
         Task<Problem?> GetProblemIncludingContestAndTestcases(int problemId, Language? language = null);
         bool CheckUserSolvedProblem(int problemId, string userId, CancellationToken cancellationToken = default);
+        Task<List<ProblemLangeuageTemplates>> GetProblemPlaceHolders(int problemId, CancellationToken cancellationToken = default);
 
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetProblemLanguagesPlaceHolders/GetProblemCodePlaceHolderQueryHandler.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetProblemLanguagesPlaceHolders/GetProblemCodePlaceHolderQueryHandler.cs
@@ -1,0 +1,23 @@
+﻿using BuildingBlocks.Core.CQRS;
+using CodeSphere.Domain.Abstractions;
+using CoreJudge.Domain.Premitives;
+using System.Net;
+
+namespace CoreJudge.Application.Features.Problem.Queries.GetProblemLanguagesPlaceHolders
+{
+    public class GetProblemCodePlaceHolderQueryHandler(IUnitOfWork _unitOfWork) : IQueryHandler<GetProblemLanguagesPlaceholdersQuery, Response>
+    {
+        public async Task<Response> Handle(GetProblemLanguagesPlaceholdersQuery query, CancellationToken cancellationToken)
+
+        {
+
+            var PlaceHolders = await _unitOfWork.ProblemRepository.GetProblemPlaceHolders(query.ProblemId, cancellationToken);
+
+            var mappedPlaceHoldersList = PlaceHolders.Select(x => new ProblemLanguagePlaceholder(x.Language, x.UserCodeTemplate)).ToList();
+
+            return await Response.SuccessAsync(mappedPlaceHoldersList, "Problem PlaceHolders Retrieved", HttpStatusCode.OK);
+
+        }
+
+    }
+}

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetProblemLanguagesPlaceHolders/GetProblemLanguagesPlaceholdersQuery.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetProblemLanguagesPlaceHolders/GetProblemLanguagesPlaceholdersQuery.cs
@@ -1,0 +1,7 @@
+﻿using BuildingBlocks.Core.CQRS;
+using CoreJudge.Domain.Premitives;
+
+namespace CoreJudge.Application.Features.Problem.Queries.GetProblemLanguagesPlaceHolders
+{
+    public record GetProblemLanguagesPlaceholdersQuery(int ProblemId) : IQuery<Response>;
+}

--- a/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetProblemLanguagesPlaceHolders/ProblemLanguagePlaceholder.cs
+++ b/src/Services/CoreJudge/CoreJudge.Application/Features/Problem/Queries/GetProblemLanguagesPlaceHolders/ProblemLanguagePlaceholder.cs
@@ -1,0 +1,6 @@
+﻿using CoreJudge.Domain.Premitives;
+
+namespace CoreJudge.Application.Features.Problem.Queries.GetProblemLanguagesPlaceHolders
+{
+    public record ProblemLanguagePlaceholder(Language Language, string Placeholder);
+}

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Repositories/ProblemRepository.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Implementation/Repositories/ProblemRepository.cs
@@ -53,6 +53,7 @@ namespace CoreJudge.Infrastructure.Implementation.Repositories
                 .FirstOrDefaultAsync(p => p.Id == problemId);
         }
 
-
+        public async Task<List<ProblemLangeuageTemplates>> GetProblemPlaceHolders(int problemId, CancellationToken cancellationToken = default)
+         => await _context.Set<ProblemLangeuageTemplates>().Where(x => x.ProblemId == problemId).ToListAsync(cancellationToken);
     }
 }

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260404153935_RanmeExecutinoTimeColumn.Designer.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260404153935_RanmeExecutinoTimeColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CoreJudge.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CoreJudge.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404153935_RanmeExecutinoTimeColumn")]
+    partial class RanmeExecutinoTimeColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260404153935_RanmeExecutinoTimeColumn.cs
+++ b/src/Services/CoreJudge/CoreJudge.Infrastructure/Migrations/20260404153935_RanmeExecutinoTimeColumn.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoreJudge.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RanmeExecutinoTimeColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "SubmitTime",
+                table: "Submissions",
+                newName: "MaxExecutionTimeMs");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "MaxExecutionTimeMs",
+                table: "Submissions",
+                newName: "SubmitTime");
+        }
+    }
+}


### PR DESCRIPTION
Introduced a GET endpoint to fetch language-specific code placeholders for a problem. Added query handler, DTOs, and repository support for retrieving code templates. Renamed the `SubmitTime` column to `MaxExecutionTimeMs` in the `Submissions` table via migration for clarity. Improves API usability and database schema accuracy.